### PR TITLE
Added mod role checks

### DIFF
--- a/say/say.py
+++ b/say/say.py
@@ -40,7 +40,7 @@ class Say:
 
         await self.bot.say(text)
 
-            
+    @checks.mod()
     @send.command(pass_context=True)
     async def channel(self, ctx, channel : discord.Channel, *, text):
         """Say a message in the chosen channel"""
@@ -100,6 +100,7 @@ class Say:
         else:
             await self.bot.say("That file doesn't seem to exist. Make sure it is the good name, try to add the extention (especially if two files have the same name) and if you just added a new file, make sure to reload the cog by typing `" + ctx.prefix + "reload say`")
 
+    @checks.mod()
     @send.command(pass_context=True)
     async def dm(self, ctx, user : discord.Member, *, text):
         """Send a message to the user in direct message. 


### PR DESCRIPTION
Currently, the "send channel" and "send dm" commands have literally no restrictions. Somebody from my server was successfully able to use the bot to send messages in channels they normally can't talk in because of denied permissions. My bot has admin perms. Similarly, the DM command can be potentially used to harass or abuse someone in DMs, without no one knowing who it really was, and the bot owner would take responsibility for that.

Adding those simple two checks should give enough protection against those two things. Please consider.