### PR TITLE
Permission error fix

### DIFF
--- a/say/say.py
+++ b/say/say.py
@@ -231,12 +231,20 @@ class Say:
         """
 
         # download the files BEFORE deleting the message
-        files = await self.download_files(ctx.message, ctx.author)
+        author = ctx.author
+        files = await self.download_files(ctx.message, author)
 
         try:
             await ctx.message.delete()
         except discord.errors.Forbidden:
-            await ctx.send(_("Not enough permissions to delete message"), delete_after=2)
+            try:
+                await ctx.send(_("Not enough permissions to delete message"), delete_after=2)
+            except discord.errors.Forbidden as e:
+                await author.send(
+                    _("Not enough permissions to delete the command message and "
+                      "to send you the permission error in the channel."), delete_after=15
+                )
+                   
 
         await self.say(ctx, text, files)
 

--- a/say/say.py
+++ b/say/say.py
@@ -241,10 +241,12 @@ class Say:
                 await ctx.send(_("Not enough permissions to delete message"), delete_after=2)
             except discord.errors.Forbidden as e:
                 await author.send(
-                    _("Not enough permissions to delete the command message and "
-                      "to send you the permission error in the channel."), delete_after=15
+                    _(
+                        "Not enough permissions to delete the command message and "
+                        "to send you the permission error in the channel."
+                    ),
+                    delete_after=15,
                 )
-                   
 
         await self.say(ctx, text, files)
 

--- a/say/say.py
+++ b/say/say.py
@@ -238,15 +238,9 @@ class Say:
             await ctx.message.delete()
         except discord.errors.Forbidden:
             try:
-                await ctx.send(_("Not enough permissions to delete message"), delete_after=2)
+                await ctx.send(_("Not enough permissions to delete messages."), delete_after=2)
             except discord.errors.Forbidden as e:
-                await author.send(
-                    _(
-                        "Not enough permissions to delete the command message and "
-                        "to send you the permission error in the channel."
-                    ),
-                    delete_after=15,
-                )
+                await author.send(_("Not enough permissions to delete messages."), delete_after=15)
 
         await self.say(ctx, text, files)
 

--- a/say/say.py
+++ b/say/say.py
@@ -180,22 +180,22 @@ class Say:
                 author = ctx.author
                 try:
                     await ctx.send(
-                        _("I am not allowed to send messages in ") + channel.mention, delete_after=1
+                        _("I am not allowed to send messages in ") + channel.mention, delete_after=2
                     )
                 except discord.errors.Forbidden as e:
                     await author.send(
                         _("I am not allowed to send messages in ") + channel.mention,
-                        delete_after=10,
+                        delete_after=15,
                     )
                     # If this fails then fuck the command author
             elif not ctx.guild.me.permissions_in(channel).attach_files:
                 try:
                     await ctx.send(
-                        _("I am not allowed to upload files in ") + channel.mention, delete_after=1
+                        _("I am not allowed to upload files in ") + channel.mention, delete_after=2
                     )
                 except discord.errors.Forbidden as e:
                     await author.send(
-                        _("I am not allowed to upload files in ") + channel.mention, delete_after=10
+                        _("I am not allowed to upload files in ") + channel.mention, delete_after=15
                     )
             else:
                 log.error(
@@ -236,7 +236,7 @@ class Say:
         try:
             await ctx.message.delete()
         except discord.errors.Forbidden:
-            await ctx.send(_("Not enough permissions to delete message"), delete_after=1)
+            await ctx.send(_("Not enough permissions to delete message"), delete_after=2)
 
         await self.say(ctx, text, files)
 

--- a/say/say.py
+++ b/say/say.py
@@ -183,7 +183,10 @@ class Say:
                         _("I am not allowed to send messages in ") + channel.mention, delete_after=1
                     )
                 except discord.errors.Forbidden as e:
-                    await author.send(_("I am not allowed to send messages in ") + channel.mention, delete_after=10)
+                    await author.send(
+                        _("I am not allowed to send messages in ") + channel.mention,
+                        delete_after=10,
+                    )
                     # If this fails then fuck the command author
             elif not ctx.guild.me.permissions_in(channel).attach_files:
                 try:
@@ -191,7 +194,9 @@ class Say:
                         _("I am not allowed to upload files in ") + channel.mention, delete_after=1
                     )
                 except discord.errors.Forbidden as e:
-                    await author.send(_("I am not allowed to upload files in ") + channel.mention, delete_after=10)
+                    await author.send(
+                        _("I am not allowed to upload files in ") + channel.mention, delete_after=10
+                    )
             else:
                 log.error(
                     f"Unknown permissions error when sending a message.\n{error_message}",

--- a/say/say.py
+++ b/say/say.py
@@ -177,13 +177,21 @@ class Say:
             await channel.send(text, files=files)
         except discord.errors.Forbidden as e:
             if not ctx.guild.me.permissions_in(channel).send_messages:
-                await ctx.send(
-                    _("I am not allowed to send messages in ") + channel.mention, delete_after=1
-                )
+                author = ctx.author
+                try:
+                    await ctx.send(
+                        _("I am not allowed to send messages in ") + channel.mention, delete_after=1
+                    )
+                except discord.errors.Forbidden as e:
+                    await author.send(_("I am not allowed to send messages in ") + channel.mention, delete_after=10)
+                    # If this fails then fuck the command author
             elif not ctx.guild.me.permissions_in(channel).attach_files:
-                await ctx.send(
-                    _("I am not allowed to upload files in ") + channel.mention, delete_after=1
-                )
+                try:
+                    await ctx.send(
+                        _("I am not allowed to upload files in ") + channel.mention, delete_after=1
+                    )
+                except discord.errors.Forbidden as e:
+                    await author.send(_("I am not allowed to upload files in ") + channel.mention, delete_after=10)
             else:
                 log.error(
                     f"Unknown permissions error when sending a message.\n{error_message}",


### PR DESCRIPTION
<!--
Hello and thanks for contributing to Laggron's Dumb Cogs
Before submitting your PR, please fill out the following questions
To tick a case, place an x between the brackets.
-->

## Pull request type

- [ ] Feature addition
- [x] Bug fix
- [ ] Grammar or minor corrections

## Does it overwrites current functionnalities?

<!--
If what you changed is just an addition, tick No
If you're modifying things inside the current functions (excluding minor corrections), tick Yes
-->

- [ ] Yes
- [x] No

## Did you test all of your changes?

- [x] Yes
- [ ] No

## Description of the changes
When a user tries to do the say command without specifying a channel and the bot doesn't have permission to send messages in the channel, it will now try to dm the command author the permission error message instead of trying to send it in the forbidden channel.
