### PR TITLE
Make `required_cogs` key a dict in `info.json` files

### DIFF
--- a/instantcmd/info.json
+++ b/instantcmd/info.json
@@ -10,7 +10,7 @@
     "description": "Command and listener maker from a code snippet through Discord",
     "hidden": false,
     "install_msg": "Thanks for installing instantcmd. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/\nEverything you need to know about setting up the cog is here.\n\nPlease keep in mind that you must know Python and discord.py for that cog. Try to create normal cogs if you don't already know how it works.",
-    "required_cogs": [],
+    "required_cogs": {},
     "requirements": [],
     "short": "Instant command maker",
     "tags": [

--- a/roleinvite/info.json
+++ b/roleinvite/info.json
@@ -10,7 +10,7 @@
     "description": "Autorole based on the invite the user used.\nIf the user joined using invite x, he will get a list of roles linked to invite x.",
     "hidden": false,
     "install_msg": "Thanks for installing roleinvite. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/roleinvite.html\nEverything you need to know about setting up the cog is here.\nFor a quick guide, type `[p]help RoleInvite`, just keep in mind that the bot needs the `Manage server` and the `Add roles` permissions.",
-    "required_cogs": [],
+    "required_cogs": {},
     "requirements": [],
     "short": "Autorole based on server's invites",
     "tags": [

--- a/say/info.json
+++ b/say/info.json
@@ -10,7 +10,7 @@
     "description": "Speak as the bot through multiple options.\nAllow file upload, rift in DM and specific destinations.",
     "hidden": false,
     "install_msg": "Thank you for installing the say cog. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/say.html\n\nType `[p]help Say` for a quick overview of the commands.",
-    "required_cogs": [],
+    "required_cogs": {},
     "requirements": [],
     "short": "Speak as the bot through multiple options.",
     "tags": [

--- a/warnsystem/info.json
+++ b/warnsystem/info.json
@@ -10,7 +10,7 @@
     "description": "An alternative to the core moderation cog, similar to Dyno.\nThe cog allows you to take actions against member and keep track with a new modlog system. It also sends a DM to the warned members.\n\nThis is the rewrite of the V2 BetterMod cog. **Note that this cog conflicts with Warnings which must be unloaded.**",
     "hidden": false,
     "install_msg": "Thank you for installing the warnsystem cog. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/warnsystem.html\n\nType `[p]help WarnSystem` for a quick overview of the commands\n**This cog conflicts with Warnings which must be unloaded.**",
-    "required_cogs": [],
+    "required_cogs": {},
     "requirements": [],
     "short": "Moderation tools, providing an alternative to core Red.",
     "tags": [


### PR DESCRIPTION
## Pull request type

- [ ] Feature addition
- [x] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes
It's nothing very important since nothing even uses this key, but `required_cogs` key should be a dict mapping a cogname to repo URL, e.g.
```json
{
    "required_cogs": {
        "adventure": "https://github.com/aikaterna/gobcog/"
    }
}
```
See [docs](https://docs.discord.red/en/latest/guide_publish_cogs.html#keys-specific-to-the-cog-info-json-case-sensitive) for more info