### PR TITLE
Warnsystem version 1.3

### DIFF
--- a/docs/warnsystem.rst
+++ b/docs/warnsystem.rst
@@ -1351,4 +1351,4 @@ code below:
         return time
 
 If this fails and you want to try to do it yourself, good luck! Full code is
-available in the ``__init__.py` file within the warnsystem directory.
+available in the ``__init__.py`` file within the warnsystem directory.

--- a/docs/warnsystem.rst
+++ b/docs/warnsystem.rst
@@ -725,8 +725,7 @@ wsunban
 
 Unbans a member from the server.
 
-If the reinvite setting is enabled (see ``[p]warnset reinvite``), the bot will
-try to send a DM to the member. This will also cancel any timer if this was a
+This will cancel any timer if this was a
 temporary ban to prevent unwanted unbans.
 
 This operation is not logged and doesn't take any reason.

--- a/docs/warnsystem.rst
+++ b/docs/warnsystem.rst
@@ -683,6 +683,271 @@ Enough info, time for explained examples.
 *   ``[p]masswarn 5 --take-actions --send-dm --reason "toxic potatoes"
     --has-role Starbucks`` Just bans everyone with the role "Starbucks"
 
+^^^^^^^^
+wsunmute
+^^^^^^^^
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]wsunmute <member>
+
+**Description**
+
+Unmutes a member muted with WarnSystem.
+
+This will remove the mute role, grant
+his roles back if they were removed by the mute (see ``[p]warnset
+removeroles``) and, if the mute was temporary, cancel the timer to prevent
+unwanted roles operations.
+
+This operation is not logged and doesn't take any reason.
+
+.. note:: wsunmute = WarnSystem unmute. Allows the core mod cog to be loaded,
+    feel free to add an alias.
+
+**Arguments**
+
+*   ``<member>``: The member you're trying to unmute.
+
+^^^^^^^
+wsunban
+^^^^^^^
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]wsunban <member>
+
+**Description**
+
+Unbans a member from the server.
+
+If the reinvite setting is enabled (see ``[p]warnset reinvite``), the bot will
+try to send a DM to the member. This will also cancel any timer if this was a
+temporary ban to prevent unwanted unbans.
+
+This operation is not logged and doesn't take any reason.
+
+.. note:: wsunban = WarnSystem unban. Allows the core mod cog to be loaded,
+    feel free to add an alias.
+
+**Arguments**
+
+*   ``<member>``: The member you're trying to unmute.
+
+^^^^^^^
+automod
+^^^^^^^
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]automod
+
+**Description**
+
+WarnSystem's automod configuration. See subcommands.
+
+.. note:: This respects Red's automod immune system. If you want to immune
+    a role or a member from all of WarnSystem's automated actions, use
+    ``[p]autoimmune`` (from Core cog).
+
+""""""""""""""
+automod enable
+""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]automod enable [confirm]
+
+**Description**
+
+Enable or disable WarnSystem's automod. This is disabled by default.
+
+.. attention:: Disabling this will disable all automod systems, even if they're
+    enabled.
+
+**Arguments**
+
+*   ``[enable]``: The new status to set. If omitted, the bot will display the
+    current setting and show how to reverse it.
+
+""""""""""""
+automod warn
+""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]automod warn
+    [p]automod warn add
+    [p]automod warn delete <index>
+    [p]automod warn list
+    [p]automod warn show <index>
+
+**Description**
+
+Configures the automod based on member's modlog. This allows automatic actions
+based on previous given warnings.
+
+For example, you can make it so if someone receives 3 level 1 warnings within a
+week, he will automatically get a level 3 (kick) warning with the reason you
+defined. A lot of options are possible.
+
+Use ``[p]automod warn add`` to add a new rule. This will open an interactive
+menu that asks for the following informations:
+
+*   The limit of warns (how many warnings should trigger the automod?)
+*   The level of the warning that will be given once the rule is triggered.
+*   The reason of the warning
+*   The optional time limit (if member gets x warnings **within duration**)
+
+*   If warn level is 2 or 5, the optional duration of the warning
+    (temp mute or ban)
+
+*   The level of the warning the bot should count (for example, only count
+    level 1 warnings). Omit to count all possible warnings.
+
+*   If the bot should only count warnings given by the automod. If this is
+    enabled, warnings given by moderators will not be counted.
+
+Your rule will be saved in a list. View this list with ``[p]automod warn list``
+to get its index. With the index, you can view the info with ``[p]automod warn
+show`` or delete it with ``[p]automod warn delete``.
+
+"""""""""""""
+automod regex
+"""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]automod regex
+    [p]automod regex add <name> <regex> <level> [time] <reason>
+    [p]automod regex delete <name>
+    [p]automod regex list
+    [p]automod regex show <name>
+
+**Description**
+
+Create and manage automod rules that will warn people if they send a message
+that matches your Regex expression. This can be used for example to warn people
+automatically if they send a Discord invite, or any link.
+
+.. note:: Regex, short for regular expression, is a way to make advanced rules
+    for checking if a phrase matches what you need, with multiple possible
+    conditions.
+
+    You can use `regex101 <https://regex101.com/>`_ to test your expressions
+    and have detailed explainations. Make sure to use Python mode.
+
+    If you don't know about Regex, I recommand you to check `Trusty's short
+    introduction to Regex for ReTrigger cog
+    <https://github.com/TrustyJAID/Trusty-cogs/tree/master/retrigger#how-to-use-retrigger>`_.
+    For a complete guide, check `Python's documentation for Regex
+    <https://docs.python.org/3/library/re.html#regular-expression-syntax>`_
+    and keep in mind `regex101 <https://regex101.com/>`_ is great for testing.
+
+Use ``[p]automod regex add`` to create a new rule with the following arguments:
+
+*   ``<name>``: The name of your rule.
+
+*   ``<regex>``: Your regular expression. Enclose in quotes if there are spaces
+    inside.
+
+*   ``<level>``: The level of the warning the bot should take.
+
+*   ``[time]``: If level is 2 or 5, optional duration for your mute or ban.
+
+*   ``<reason>``: The reason of the warning. You can use the following keywords
+    inside your reason:
+
+    *   ``{member}``: the warned member in the format "name#0000". Other
+        formats are possible:
+
+        *   ``{member.mention}``
+        *   ``{member.name}``
+        *   ``{member.id}``
+
+    *   ``{channel}``: the channel where the message was send in the format
+        "channel-name". Other possible formats:
+
+        *   ``{channel.mention}``
+        *   ``{channel.category}``
+        *   ``{channel.id}``
+
+    *   ``{guild}``: the current server, if needed, in the format "server
+        name". Other possible formats:
+
+        *   ``{guild.id}``
+
+    Click for the list of all possible formats for :class:`~discord.Member`,
+    :class:`~discord.Channel` and :class:`discord.Guild`.
+
+Example: ``[p]automod regex add discord_invite
+"(?i)(discord\.gg|discordapp\.com\/invite|discord\.me)\/(\S+)"
+1 Discord invite sent in {channel.mention}.``
+
+You can then view the informations of that rule with ``[p]automod regex show``,
+delete it with ``[p]automod regex delete`` and list other rules with
+``[p]automod regex list``.
+
+""""""""""""""""
+automod antispam
+""""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]automod antispam
+    [p]automod antispam delay <delay>
+    [p]automod antispam enable [enable]
+    [p]automod antispam info
+    [p]automod antispam threshold <max_messages> <delay>
+    [p]automod antispam warn <level> [duration] <reason>
+
+**Description**
+
+Antispam system management. This will warn members if they send messages too
+quickly.
+
+Use ``[p]automod antispam enable`` to enable the antispam system. You can
+enable and disable it without affecting other automod functions. **You still
+need to have automod enabled.**
+
+You will then have the antispam enabled with default settings:
+
+*   Maximum of 5 messages within 5 seconds. Modify with ``[p]automod antispam
+    threshold``.
+
+*   One reminder within a minute before warn. Modify with ``[p]automod antispam
+    delay``.
+
+*   Level 1 warn applied for the reason "Sending messages too fast.". Modify
+    with ``[p]automod antispam warn``.
+
+You can check these info with ``[p]automod antispam info``.
+
+A bit more details for the "reminder": if the antispam is triggered, the bot
+will send a text warning directly in the channel, mentionning the member
+to warn him. If the antispam is triggered a second time within a minute, then
+the bot will take actions, as set with ``[p]automod antispam warn``.
+
+This is a way to make people aware of the antispam, most of the members will
+quickly correct their behaviour and avoid a spam of warnings. Of course you can
+increase or decrease this period with ``[p]automod antispam delay`` (in
+seconds). You can completly disable this and immediatly take actions by
+settings a delay of 0.
+
 ^^^^^^^
 warnset
 ^^^^^^^
@@ -887,6 +1152,30 @@ You can use the following keys in your custom description:
 
 *   ``<description>``: The new description.
 
+""""""""""""""""""""
+warnset detectmanual
+""""""""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]warnset detectmanual [enable]
+
+**Description**
+
+Defines if you want the bot to automatically log manual bans taken on the
+server. This will send a message in the modlog and create a case assigned to
+the banned member with the reason set via Discord. However, the bot will not be
+able to send a DM.
+
+This is disabled by default.
+
+**Arguments**
+
+*   ``[enable]``: The new status to set. If omitted, the bot will display the
+    current setting and show how to reverse it.
+
 """""""""""""""""
 warnset hierarchy
 """""""""""""""""
@@ -934,10 +1223,44 @@ You can also provide an existing role to set it as the new mute role.
 **Permissions won't be modified in any channel in that case**, so make sure you
 have the right permissions setup for that role.
 
+.. tip:: You can use ``[p]warnset autoupdate`` to automatically update new
+    channels created on your server, to make sure the mute role stays efficient
+    everywhere.
+
+.. tip:: The ``[p]warnset refreshmuterole`` will iterate all channels and make
+    sure the channels have the correct permissions set for the mute role ("send
+    messages", "add reactions" and "speak" permissions denied).
+
 **Arguments**
 
 *   ``[role]``: The exact name of an existing role to set it as the mute role.
     If this is omitted, a new role will be created.
+
+"""""""""""""""""""""""
+warnset refreshmuterole
+"""""""""""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]warnset refreshmuterole
+
+**Description**
+
+Check if the mute role's permissions match your server channels. If permissions
+are wrong somewhere, they will be adjusted. The bot checks for the following
+permissions:
+
+*   Send messages denied
+*   Add reactions denied
+*   Speak denied
+
+This checks text and voice channels, and categories too. Once the bot finished,
+the number of updated channels will be shown.
+
+This is useful if you lost track of the permissions, or didn't enable the
+autoupdate function (see ``[p]warnset autoupdate``).
 
 """"""""""""""""
 warnset reinvite

--- a/warnsystem/README.md
+++ b/warnsystem/README.md
@@ -91,7 +91,7 @@ You can also support me on Patreon and get exclusive rewards!
 
 If you're reading this from Github and want to contribute or just understand the source code, I'm gonna stop you right there. Indeed, the cog is a bit complex so let me explain a bit how each file work before source diving.
 
-- `__init__.py` The first file invoked when loading the cog. Nothing really useful here, only the check for the Warnings cog.
+- `__init__.py` The first file invoked when loading the cog. Nothing really useful here, only the check for the Warnings cog. *Added in 1.3:* Data conversion stuff is located here.
 - `abc.py` Just stuff for the inheritance of some classes.
 - `api.py` The most important functions are there, such as warning a member, getting the warns, generating embeds... Those functions don't need a context to be invoked.
 - `converters.py` The argument parser for the `[p]masswarn` command. Informations are just extracted from text and they're given back to the command (works like a discord.py converter).

--- a/warnsystem/__init__.py
+++ b/warnsystem/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import importlib.util
 
+from .warnsystem import WarnSystem
+
 try:
     from redbot.core.errors import CogLoadError
 except ImportError:
@@ -12,18 +14,96 @@ if not importlib.util.find_spec("dateutil"):
         "Use the command `[p]pipinstall python-dateutil` or type "
         "`pip3 install python-dateutil` in the terminal to install the library."
     )
-from .warnsystem import WarnSystem
 
 log = logging.getLogger("laggron.warnsystem")
+
+
+def _save_backup(config):
+    import json
+    from datetime import datetime
+    from redbot.core.data_manager import cog_data_path
+
+    date = datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
+    path = cog_data_path(raw_name="WarnSystem") / f"settings-backup-{date}.json"
+    data = json.dumps(config.driver.data)
+    with open(path.absolute(), "w") as file:
+        file.write(data)
+    log.info(f"Backup file saved at '{path.absolute()}', now starting conversion...")
+
+
+async def _convert_to_v1(bot, config):
+    for guild in bot.guilds:
+        warns = await config.guild(guild).temporary_warns()
+        if warns == {}:
+            continue
+        if warns:
+            new_dict = {}
+            for case in warns:
+                member = case["member"]
+                del case["member"]
+                new_dict[member] = case
+            await config.guild(guild).temporary_warns.set(new_dict)
+        else:
+            # config does not update [] to {}
+            # we fill a dict with random values to force config to set a dict
+            # then we empty that dict
+            await config.guild(guild).temporary_warns.set({None: None})
+            await config.guild(guild).temporary_warns.set({})
+
+
+async def update_config(bot, config):
+    """
+    Warnsystem 1.3.0 requires an update with the config body.
+    Temporary warns are stored as a dict instead of a list.
+    """
+    if await config.data_version() == "0.0":
+        all_guilds = await config.all_guilds()
+        if not any("temporary_warns" in x for x in all_guilds.values()):
+            await config.data_version.set("1.0")
+            return
+        log.info(
+            "WarnSystem 1.3.0 changed the way data is stored. Your data will be updated. "
+            "A copy will be created. If something goes wrong and the data is not usable, keep "
+            "that file safe and ask support on how to recover the data."
+        )
+        # perform a backup, any exception MUST be raised
+        await bot.loop.run_in_executor(None, _save_backup, config)
+        # we consider we have a safe backup at this point
+        await _convert_to_v1(bot, config)
+        await config.data_version.set("1.0")
+        log.info(
+            "All data successfully converted! The cog will now load. Keep the backup file for "
+            "a bit since problems can occur after cog load."
+        )
+        # phew
 
 
 async def setup(bot):
     n = WarnSystem(bot)
     # the cog conflicts with the core Warnings cog, we must check that
     if "Warnings" in bot.cogs:
+        log.handlers = []  # still need some cleaning up
         raise CogLoadError(
             "You need to unload the Warnings cog to load "
             "this cog. Type `[p]unload warnings` and try again."
         )
+    try:
+        await update_config(bot, n.data)
+    except Exception as e:
+        log.critical(
+            "Cannot update config. Data can be corrupted, do not try to load the cog."
+            "Contact support for further instructions.",
+            exc_info=e,
+        )
+        log.handlers = []  # still need some cleaning up
+        raise CogLoadError(
+            "After an update, the cog tried to perform changes to the saved data but an error "
+            "occured. Read your console output or warnsystem.log (located over "
+            "Red-DiscordBot/cogs/WarnSystem) for more details.\n"
+            "**Do not try to load the cog again until the issue is resolved, the data might be"
+            "corrupted.** Contacting support is advised (Laggron's support server or official "
+            "3rd party cog support server, #support_laggrons-dumb-cogs channel)."
+        ) from e
     bot.add_cog(n)
+    n.task = bot.loop.create_task(n._loop_task())
     log.debug("Cog successfully loaded on the instance.")

--- a/warnsystem/__init__.py
+++ b/warnsystem/__init__.py
@@ -105,5 +105,8 @@ async def setup(bot):
             "3rd party cog support server, #support_laggrons-dumb-cogs channel)."
         ) from e
     bot.add_cog(n)
-    n.task = bot.loop.create_task(n._loop_task())
+    await n.cache.init_automod_enabled()
+    n.task = bot.loop.create_task(n.api._loop_task())
+    if n.cache.automod_enabled:
+        n.api.enable_automod()
     log.debug("Cog successfully loaded on the instance.")

--- a/warnsystem/abc.py
+++ b/warnsystem/abc.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     from redbot.core import Config
     from redbot.core.bot import Red
     from .cache import MemoryCache
+    from .api import API
 
 
 class MixinMeta(ABC):
@@ -20,3 +21,4 @@ class MixinMeta(ABC):
         self.bot: Red
         self.data: Config
         self.cache: MemoryCache
+        self.api: API

--- a/warnsystem/abc.py
+++ b/warnsystem/abc.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from redbot.core import Config
     from redbot.core.bot import Red
-    from .api import API
 
 
 class MixinMeta(ABC):
@@ -19,4 +18,5 @@ class MixinMeta(ABC):
     def __init__(self, *_args):
         self.bot: Red
         self.data: Config
-        self.api: API
+        self.mute_roles: dict
+        self.temp_actions: dict

--- a/warnsystem/abc.py
+++ b/warnsystem/abc.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from redbot.core import Config, commands
+    from redbot.core import Config
     from redbot.core.bot import Red
     from .api import API
 

--- a/warnsystem/abc.py
+++ b/warnsystem/abc.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from redbot.core import Config
     from redbot.core.bot import Red
+    from .cache import MemoryCache
 
 
 class MixinMeta(ABC):
@@ -15,8 +16,7 @@ class MixinMeta(ABC):
     Credit to https://github.com/Cog-Creators/Red-DiscordBot (mod cog) for all mixin stuff.
     """
 
-    def __init__(self, *_args):
+    def __init__(self):
         self.bot: Red
         self.data: Config
-        self.mute_roles: dict
-        self.temp_actions: dict
+        self.cache: MemoryCache

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -2,15 +2,13 @@ import asyncio
 import discord
 import logging
 import re
-import abc
 
 from copy import deepcopy
 from typing import Union, Optional, Iterable, Callable, Awaitable
 from datetime import datetime, timedelta
 
-from redbot.core.utils.mod import is_allowed_by_hierarchy
 from redbot.core.i18n import Translator
-from redbot.core.commands import BadArgument, Converter, MemberConverter
+from redbot.core.commands import BadArgument, MemberConverter
 
 try:
     from redbot.core.modlog import get_modlog_channel as get_red_modlog_channel

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -376,10 +376,10 @@ class API:
                 if time:
                     log["time"] = self._get_datetime(time)
                 # gotta get that state somehow
-                log["member"] = self.bot.get_user(member) or UnavailableMember(
+                log["member"] = self.bot.get_user(int(member)) or UnavailableMember(
                     self.bot, self.bot.user._state, member
                 )
-                log["author"] = self.bot.get_user(log["author"]) or UnavailableMember(
+                log["author"] = self.bot.get_user(int(log["author"])) or UnavailableMember(
                     self.bot, self.bot.user._state, log["author"]
                 )
                 all_cases.append(log)

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -629,7 +629,7 @@ class API:
         log_embed.add_field(name=_("Status"), value=current_status(True), inline=False)
         log_embed.set_footer(text=today)
         log_embed.set_thumbnail(url=await self.data.guild(guild).thumbnails.get_raw(level))
-        log_embed.color = await self.data.guild(guild).colors.get_raw(level)
+        log_embed.colour = await self.data.guild(guild).colors.get_raw(level)
         log_embed.url = await self.data.guild(guild).url()
         log_embed.set_image(url=link.group() if link else "")
         if not message_sent:

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -31,6 +31,7 @@ class FakeRole:
     """
 
     position = 0
+    colour = discord.Embed.Empty
 
 
 class UnavailableMember(discord.abc.User, discord.abc.Messageable):

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -629,7 +629,7 @@ class API:
             log_embed.add_field(name=_("Duration"), value=duration, inline=True)
         log_embed.add_field(name=_("Reason"), value=reason + mod_message, inline=False)
         log_embed.add_field(name=_("Status"), value=current_status(True), inline=False)
-        log_embed.set_footer(text=today)
+        log_embed.timestamp = datetime.now()
         log_embed.set_thumbnail(url=await self.data.guild(guild).thumbnails.get_raw(level))
         log_embed.colour = await self.data.guild(guild).colors.get_raw(level)
         log_embed.url = await self.data.guild(guild).url()

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -636,8 +636,8 @@ class API:
         log_embed.set_image(url=link.group() if link else "")
         if not message_sent:
             log_embed.description += _(
-                "\n\n***The message couldn't be delivered to the member. We may don't "
-                "have a server in common or he blocked me/messages from this guild.***"
+                "\n\n***The message could not be delivered to the user. They may have DMs "
+                "disabled, blocked the bot, or may not have a mutual server.***"
             )
 
         # embed for the member in DM

--- a/warnsystem/automod.py
+++ b/warnsystem/automod.py
@@ -1,13 +1,16 @@
 import discord
+import asyncio
 
 from redbot.core import commands
 from redbot.core import checks
 from redbot.core.i18n import Translator
 from redbot.core.utils import menus
+from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 from redbot.core.utils.chat_formatting import pagify, box
 from redbot.core.commands.converter import TimedeltaConverter
 
 from typing import Optional
+from datetime import timedelta
 
 from .abc import MixinMeta
 from .converters import ValidRegex
@@ -19,6 +22,82 @@ class AutomodMixin(MixinMeta):
     """
     Automod configuration.
     """
+
+    async def _ask_for_value(
+        self,
+        ctx: commands.Context,
+        bot_msg: discord.Message,
+        embed: discord.Embed,
+        description: str,
+        need: str = "same_context",
+        optional: bool = False,
+    ):
+        embed.description = description
+        if optional:
+            embed.set_footer(text=_('\n\nType "skip" to omit this parameter.'))
+        await bot_msg.edit(content="", embed=embed)
+        pred = getattr(MessagePredicate, need, MessagePredicate.same_context)(ctx)
+        user_msg = await self.bot.wait_for("message", check=pred, timeout=30)
+        if ctx.channel.permissions_for(ctx.guild.me).manage_messages:
+            await user_msg.delete()
+        if optional and user_msg.content == "skip":
+            return None
+        if need == "time":
+            try:
+                time = await TimedeltaConverter().convert(ctx, user_msg.content)
+            except commands.BadArgument:
+                await ctx.send(_("Invalid time format."))
+                return await self._ask_for_value(ctx, bot_msg, embed, description, need, optional)
+            else:
+                return time
+        if need == "same_context":
+            return user_msg.content
+        return pred.result
+
+    def _format_embed_for_autowarn(
+        self,
+        embed: discord.Embed,
+        number_of_warns: int,
+        warn_level: int,
+        warn_reason: str,
+        lock_level: int,
+        only_automod: bool,
+        time: timedelta,
+        duration: timedelta,
+    ) -> discord.Embed:
+        time_str = _("Not set.") if not time else self.api._format_timedelta(time)
+        duration_str = _("Not set.") if not duration else self.api._format_timedelta(duration)
+        embed.description = _("Number of warnings until action: {num}\n").format(
+            num=number_of_warns
+        )
+        embed.description += _("Warning level: {level}\n").format(level=warn_level)
+        embed.description += _("Warning reason: {reason}\n").format(reason=warn_reason)
+        embed.description += _("Time interval: {time}\n").format(time=time_str)
+        if warn_level == 2 or warn_level == 5:
+            embed.description += _("Duration: {time}\n").format(time=duration_str)
+        embed.description += _("Lock to level: {level}\n").format(
+            level=_("disabled") if lock_level == 0 else lock_level
+        )
+        embed.description += _("Only count automod: {enabled}\n\n").format(
+            enabled=_("yes") if only_automod else _("no")
+        )
+        embed.add_field(
+            name=_("What will happen:"),
+            value=_(
+                "If a member receives {number}{level_lock} warnings{from_bot}{within_time}, the "
+                "bot will set a level {level} warning on him{duration} for the reason: {reason}"
+            ).format(
+                number=number_of_warns,
+                level_lock=_(" level {level}").format(level=lock_level) if lock_level else "",
+                from_bot=_(" from the automod") if only_automod else "",
+                within_time=_(" within {time}").format(time=time_str) if time else "",
+                level=warn_level,
+                duration=_(" during {time}").format(time=duration_str) if duration else "",
+                reason=warn_reason,
+            ),
+            inline=False,
+        )
+        return embed
 
     @commands.group()
     @checks.admin()
@@ -36,10 +115,14 @@ class AutomodMixin(MixinMeta):
         guild = ctx.guild
         if confirm is not None:
             if confirm:
+                if not self.cache.automod_enabled:
+                    self.api.enable_automod()
                 await self.cache.add_automod_enabled(guild)
                 await ctx.send(_("Automod is now enabled."))
             else:
                 await self.cache.remove_automod_enabled(guild)
+                if not self.cache.automod_enabled:
+                    self.api.disable_automod()
                 await ctx.send(_("Automod is now disabled."))
         else:
             current = await self.data.guild(guild).automod.enabled()
@@ -84,7 +167,7 @@ class AutomodMixin(MixinMeta):
         - `{guild}`
 
         Example: `[p]automod regex add discord_invite \
-"(?i)(discord\.gg|discordapp\.com\/invite|discord\.me)\/(\S+)" \
+"(?i)(discord\\.gg|discordapp\\.com\\/invite|discord\\.me)\\/(\\S+)" \
 1 Discord invite sent in {channel.mention}.`
         """
         guild = ctx.guild
@@ -120,10 +203,302 @@ class AutomodMixin(MixinMeta):
         guild = ctx.guild
         automod_regex = await self.cache.get_automod_regex(guild)
         text = ""
-        for name, value in automod_regex:
-            text += f"+ {name}\n{value}\n\n"
+        if not automod_regex:
+            await ctx.send(_("Nothing registered."))
+            return
+        for name, value in automod_regex.items():
+            text += (
+                f"+ {name}\nLevel {value['level']} warning. Reason: {value['reason'][:40]}...\n\n"
+            )
         messages = []
         pages = list(pagify(text, delims=["\n\n", "\n"], priority=True, page_length=1900))
         for i, page in enumerate(pages):
-            messages += _("Page {i}/{total}").format(i=i + 1, total=len(pages)) + box(page, "md")
+            messages.append(
+                _("Page {i}/{total}").format(i=i + 1, total=len(pages)) + box(page, "diff")
+            )
         await menus.menu(ctx, pages=messages, controls=menus.DEFAULT_CONTROLS)
+
+    @automod_regex.command(name="show")
+    async def automod_regex_show(self, ctx: commands.Context, name: str):
+        """
+        Show details of a Regex trigger.
+        """
+        guild = ctx.guild
+        try:
+            automod_regex = (await self.cache.get_automod_regex(guild))[name]
+        except KeyError:
+            await ctx.send(_("That Regex trigger doesn't exist."))
+            return
+        embed = discord.Embed(title=_("Regex trigger: {name}").format(name=name))
+        embed.description = _("Regex trigger details.")
+        embed.add_field(
+            name=_("Regular expression"), value=box(automod_regex["regex"].pattern), inline=False
+        )
+        embed.add_field(
+            name=_("Warning"),
+            value=_("**Level:** {level}\n**Reason:** {reason}\n**Duration:** {time}").format(
+                level=automod_regex["level"],
+                reason=automod_regex["reason"],
+                time=self.api._format_timedelta(automod_regex["time"])
+                if automod_regex["time"]
+                else _("Not set."),
+            ),
+            inline=False,
+        )
+        await ctx.send(embed=embed)
+
+    @automod.group(name="warn")
+    async def automod_warn(self, ctx: commands.Context):
+        """
+        Trigger actions when a member get x warnings within the specified time.
+
+        For example, if a member gets 3 warnings within a day, you can make the bot automatically
+set him a level 3 warning with the given reason.
+        It is also possible to only include warnings given by the bot when counting.
+        """
+        pass
+
+    @automod_warn.command(name="add")
+    async def automod_warn_add(self, ctx: commands.Context):
+        """
+        Create a new automated warn based on member's modlog.
+
+        Multiple parameters are needed, you will open an interactive menu.
+        """
+        guild = ctx.guild
+        msg = await ctx.send(_("Loading configuration menu..."))
+        await asyncio.sleep(1)
+        embed = discord.Embed(title=_("Automatic warn setup"))
+        embed.colour = await self.bot.get_embed_colour(ctx)
+        try:
+            while True:
+                number_of_warns = await self._ask_for_value(
+                    ctx,
+                    msg,
+                    embed,
+                    _("How many warnings should trigger the automod?"),
+                    need="valid_int",
+                )
+                if number_of_warns > 1:
+                    break
+                else:
+                    await ctx.send(_("This must be higher than 1."))
+            while True:
+                warn_level = await self._ask_for_value(
+                    ctx,
+                    msg,
+                    embed,
+                    _("What's the level of the automod's warning?"),
+                    need="valid_int",
+                )
+                if 1 <= warn_level <= 5:
+                    break
+                else:
+                    await ctx.send(_("Level must be between 1 and 5."))
+            warn_reason = await self._ask_for_value(
+                ctx, msg, embed, _("What's the reason of the automod's warning?"), optional=True,
+            )
+            time: timedelta = await self._ask_for_value(
+                ctx,
+                msg,
+                embed,
+                _(
+                    "For how long should this automod be active?\n\n"
+                    "For example, you can make it trigger if a member got 3 warnings"
+                    " __within a day__\nOmitting this value will make the automod look across the "
+                    "entire member's modlog without time limit.\n\n"
+                    "Format is the same as temp mutes/bans: `30m` = 30 minutes, `2h` = 2 hours, "
+                    "`4d` = 4 days..."
+                ),
+                need="time",
+                optional=True,
+            )
+            duration = None
+            if warn_level == 2 or warn_level == 5:
+                duration: timedelta = await self._ask_for_value(
+                    ctx,
+                    msg,
+                    embed,
+                    _(
+                        "Level 2 and 5 warnings can be temporary (unmute or unban "
+                        "after some time). For how long should the the member stay punished?\n"
+                        "Skip this value to make the mute/ban unlimited.\n"
+                        "Time format is the same as the previous question."
+                    ),
+                    need="time",
+                    optional=True,
+                )
+            while True:
+                lock_level = await self._ask_for_value(
+                    ctx,
+                    msg,
+                    embed,
+                    _(
+                        "Should the automod be triggered only by specific level? "
+                        "(e.g. only 3 level 1 warnings should trigger)\n"
+                        "Send the level or `0` to disable."
+                    ),
+                    need="valid_int",
+                )
+                if 0 <= lock_level <= 5:
+                    break
+                else:
+                    await ctx.send(_("Level must be between 0 and 5."))
+                    await asyncio.sleep(1)
+            only_automod = await self._ask_for_value(
+                ctx,
+                msg,
+                embed,
+                _(
+                    "Should the automod be triggered only by other automod warnings?\n"
+                    "If enabled, warnings issued by a normal moderator "
+                    "will not be added to the count.\n\n"
+                    "Type `yes` or `no`."
+                ),
+                need="yes_or_no",
+                optional=False,
+            )
+        except asyncio.TimeoutError:
+            await ctx.send(_("Timed out."))
+            return
+        await msg.delete()
+        embed = discord.Embed(title=_("Summary of auto warn"))
+        embed = self._format_embed_for_autowarn(
+            embed,
+            number_of_warns,
+            warn_level,
+            warn_reason,
+            lock_level,
+            only_automod,
+            time,
+            duration,
+        )
+        embed.add_field(name="\u200B", value=_("Is this correct?"), inline=False)
+        message = await ctx.send(embed=embed)
+        pred = ReactionPredicate.yes_or_no(message, ctx.author)
+        menus.start_adding_reactions(message, ReactionPredicate.YES_OR_NO_EMOJIS)
+        try:
+            await self.bot.wait_for("reaction_add", check=pred, timeout=30)
+        except asyncio.TimeoutError:
+            await ctx.send(_("Timed out."))
+            return
+        if not pred.result:
+            await ctx.send(_("Please restart the process over."))
+            return
+        async with self.data.guild(guild).automod.warnings() as warnings:
+            warnings.append(
+                {
+                    "number": number_of_warns,
+                    "time": time.total_seconds() if time else None,
+                    "level": lock_level,
+                    "automod_only": only_automod,
+                    "warn": {
+                        "level": warn_level,
+                        "reason": warn_reason,
+                        "duration": duration.total_seconds() if duration else None,
+                    },
+                }
+            )
+        await ctx.send(_("The new automatic warn was successfully saved!"))
+
+    @automod_warn.command(name="delete", aliases=["del", "remove"])
+    async def automod_warn_delete(self, ctx: commands.Context, index: int):
+        """
+        Delete an automated warning.
+
+        You can find the index with the `[p]automod warn list` command.
+        """
+        guild = ctx.guild
+        if index < 0:
+            await ctx.send(_("Invalid index, must be positive."))
+            return
+        async with await self.data.guild(guild).automod.warnings() as warnings:
+            try:
+                autowarn = warnings[index]
+            except IndexError:
+                await ctx.send(_("There isn't such automated warn."))
+                return
+            embed = discord.Embed(title=_("Deletion of the following auto warn:"))
+            duration = autowarn["warn"]["duration"]
+            embed = self._format_embed_for_autowarn(
+                embed,
+                autowarn["number"],
+                autowarn["warn"]["level"],
+                autowarn["warn"]["reason"],
+                autowarn["level"],
+                autowarn["automod_only"],
+                timedelta(seconds=autowarn["time"]),
+                timedelta(seconds=duration) if duration else None,
+            )
+            embed.set_footer(text=_("Confirm with the reactions below."))
+            msg = await ctx.send(embed=embed)
+            menus.start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
+            pred = ReactionPredicate.yes_or_no(msg, ctx.author)
+            try:
+                await self.bot.wait_for("reaction_add", check=pred, timeout=30)
+            except asyncio.TimeoutError:
+                await ctx.send(_("Timed out."))
+                return
+            if not pred.result:
+                await ctx.send(_("The auto warn wasn't deleted."))
+                return
+            warnings.pop(index)
+        await ctx.send(_("Automated warning successfully deleted."))
+
+    @automod_warn.command(name="list")
+    async def automod_warn_list(self, ctx: commands.Context):
+        """
+        Lists automated warnings on this server.
+        """
+        guild = ctx.guild
+        autowarns = await self.data.guild(guild).automod.warnings()
+        if not autowarns:
+            await ctx.send(_("No automatic warn registered."))
+            return
+        text = ""
+        for index, data in enumerate(autowarns):
+            text += _("{index}. level {level} warn (need {number} warns to trigger)\n").format(
+                index=index, level=data["warn"]["level"], number=data["number"],
+            )
+        text = list(pagify(text, page_length=1900))
+        pages = []
+        for i, page in enumerate(text):
+            pages.append(
+                _("Page {i}/{total}\n\n").format(i=i + 1, total=len(text))
+                + page
+                + _("\n*Type `{prefix}automod warn show` to view details.*").format(
+                    prefix=ctx.clean_prefix
+                )
+            )
+        await menus.menu(ctx, pages=pages, controls=menus.DEFAULT_CONTROLS)
+
+    @automod_warn.command(name="show")
+    async def automod_warn_show(self, ctx: commands.Context, index: int):
+        """
+        Shows the contents of an automatic warn.
+
+        Index is shown by the `[p]automod warn list` command.
+        """
+        guild = ctx.guild
+        if index < 0:
+            await ctx.send(_("Invalid index, must be positive."))
+            return
+        async with self.data.guild(guild).automod.warnings() as warnings:
+            try:
+                autowarn = warnings[index]
+            except IndexError:
+                await ctx.send(_("There isn't such automated warn."))
+                return
+        embed = discord.Embed(title=_("Settings of auto warn {index}").format(index=index))
+        duration = autowarn["warn"]["duration"]
+        embed = self._format_embed_for_autowarn(
+            embed,
+            autowarn["number"],
+            autowarn["warn"]["level"],
+            autowarn["warn"]["reason"],
+            autowarn["level"],
+            autowarn["automod_only"],
+            timedelta(seconds=autowarn["time"]),
+            timedelta(seconds=duration) if duration else None,
+        )
+        await ctx.send(embed=embed)

--- a/warnsystem/automod.py
+++ b/warnsystem/automod.py
@@ -1,0 +1,129 @@
+import discord
+
+from redbot.core import commands
+from redbot.core import checks
+from redbot.core.i18n import Translator
+from redbot.core.utils import menus
+from redbot.core.utils.chat_formatting import pagify, box
+from redbot.core.commands.converter import TimedeltaConverter
+
+from typing import Optional
+
+from .abc import MixinMeta
+from .converters import ValidRegex
+
+_ = Translator("WarnSystem", __file__)
+
+
+class AutomodMixin(MixinMeta):
+    """
+    Automod configuration.
+    """
+
+    @commands.group()
+    @checks.admin()
+    async def automod(self, ctx: commands.Context):
+        """
+        WarnSystem automod configuration.
+        """
+        pass
+
+    @automod.command(name="enable")
+    async def automod_enable(self, ctx: commands.Context, confirm: bool = None):
+        """
+        Enable or disable WarnSystem's automod.
+        """
+        guild = ctx.guild
+        if confirm is not None:
+            if confirm:
+                await self.cache.add_automod_enabled(guild)
+                await ctx.send(_("Automod is now enabled."))
+            else:
+                await self.cache.remove_automod_enabled(guild)
+                await ctx.send(_("Automod is now disabled."))
+        else:
+            current = await self.data.guild(guild).automod.enabled()
+            await ctx.send(
+                _(
+                    "Automod is currently {state}.\n"
+                    "Type `{prefix}automod enable {arg}` to {action} it."
+                ).format(
+                    state=_("enabled") if current else _("disabled"),
+                    prefix=ctx.clean_prefix,
+                    arg=not current,
+                    action=_("enable") if not current else _("disable"),
+                )
+            )
+
+    @automod.group(name="regex")
+    async def automod_regex(self, ctx: commands.Context):
+        """
+        Trigger warnings when a regular expression matches a message like ReTrigger.
+        """
+        pass
+
+    @automod_regex.command(name="add")
+    async def automod_regex_add(
+        self,
+        ctx: commands.Context,
+        name: str,
+        regex: ValidRegex,
+        level: int,
+        time: Optional[TimedeltaConverter],
+        *,
+        reason: str,
+    ):
+        """
+        Create a new Regex trigger for a warning.
+
+        Use https://regex101.com/ to test your expression.
+
+        Possible keywords:
+        - `{member}`
+        - `{channel}`
+        - `{guild}`
+
+        Example: `[p]automod regex add discord_invite \
+"(?i)(discord\.gg|discordapp\.com\/invite|discord\.me)\/(\S+)" \
+1 Discord invite sent in {channel.mention}.`
+        """
+        guild = ctx.guild
+        automod_regex = await self.cache.get_automod_regex(guild)
+        if name in automod_regex:
+            await ctx.send(_("That name is already used."))
+            return
+        if time:
+            if level == 2 or level == 5:
+                time = self.api._format_timedelta(time)
+            else:
+                time = None
+        await self.cache.add_automod_regex(guild, name, regex, level, time, reason)
+        await ctx.send(_("Regex trigger added!"))
+
+    @automod_regex.command(name="delete", aliases=["del", "remove"])
+    async def automod_regex_delete(self, ctx: commands.Context, name: str):
+        """
+        Delete a Regex trigger.
+        """
+        guild = ctx.guild
+        if name not in await self.cache.get_automod_regex(guild):
+            await ctx.send(_("That Regex trigger doesn't exist."))
+            return
+        await self.cache.remove_automod_regex(guild, name)
+        await ctx.send(_("Regex trigger removed."))
+
+    @automod_regex.command(name="list")
+    async def automod_regex_list(self, ctx: commands.Context):
+        """
+        Lists all Regex triggers.
+        """
+        guild = ctx.guild
+        automod_regex = await self.cache.get_automod_regex(guild)
+        text = ""
+        for name, value in automod_regex:
+            text += f"+ {name}\n{value}\n\n"
+        messages = []
+        pages = list(pagify(text, delims=["\n\n", "\n"], priority=True, page_length=1900))
+        for i, page in enumerate(pages):
+            messages += _("Page {i}/{total}").format(i=i + 1, total=len(pages)) + box(page, "md")
+        await menus.menu(ctx, pages=messages, controls=menus.DEFAULT_CONTROLS)

--- a/warnsystem/cache.py
+++ b/warnsystem/cache.py
@@ -55,9 +55,7 @@ class MemoryCache:
 
     async def get_mute_role(self, guild: discord.Guild):
         role_id = self.mute_roles.get(guild.id, False)
-        if role_id is not None:
-            if role_id is False:
-                role_id = None
+        if role_id is not False:
             return role_id
         role_id = await self.data.guild(guild).mute_role()
         if role_id:
@@ -70,7 +68,7 @@ class MemoryCache:
 
     async def get_temp_action(self, guild: discord.Guild, member: Optional[discord.Member] = None):
         guild_temp_actions = self.temp_actions.get(guild.id, {})
-        if guild_temp_actions is not None:
+        if not guild_temp_actions:
             guild_temp_actions = await self.data.guild(guild).temporary_warns.all()
             if guild_temp_actions:
                 self.temp_actions[guild.id] = guild_temp_actions
@@ -112,7 +110,7 @@ class MemoryCache:
 
     async def get_automod_regex(self, guild: discord.Guild):
         automod_regex = self.automod_regex.get(guild.id, {})
-        if automod_regex is not None:
+        if automod_regex:
             return automod_regex
         automod_regex = await self.data.guild(guild).automod.regex()
         for name, regex in automod_regex.items():

--- a/warnsystem/cache.py
+++ b/warnsystem/cache.py
@@ -1,10 +1,12 @@
 import discord
 import logging
 import contextlib
+import re
 
-from typing import Mapping, Optional
 from redbot.core import Config
 from redbot.core.bot import Red
+
+from typing import Mapping, Optional
 
 log = logging.getLogger("laggron.warnsystem")
 
@@ -21,6 +23,13 @@ class MemoryCache:
 
         self.mute_roles = {}
         self.temp_actions = {}
+        self.automod_enabled = []
+        self.automod_regex = {}
+
+    async def init_automod_enabled(self):
+        for guild in self.bot.guilds:
+            if await self.data.guild(guild).automod.enabled():
+                self.automod_enabled.append(guild.id)
 
     async def _debug_info(self) -> str:
         """
@@ -30,9 +39,9 @@ class MemoryCache:
         """
         config_data = await self.data.all_guilds()
         mute_roles_cached = len(self.mute_roles)
-        mute_roles = sum((x for x in config_data.values() if x["mute_role"] is not None))
+        mute_roles = len([x for x in config_data.values() if x["mute_role"] is not None])
         guild_temp_actions_cached = len(self.temp_actions)
-        guild_temp_actions = len(config_data["temporary_warns"])
+        guild_temp_actions = len([x for x in config_data.values() if x["temporary_warns"]])
         temp_actions_cached = sum(len(x) for x in self.temp_actions.values())
         temp_actions = sum((len(x["temporary_warns"]) for x in config_data.values()))
         text = (
@@ -49,7 +58,8 @@ class MemoryCache:
         if role_id:
             return role_id
         role_id = await self.data.guild(guild).mute_role()
-        self.mute_roles[guild.id] = role_id
+        if role_id:
+            self.mute_roles[guild.id] = role_id
         return role_id
 
     async def update_mute_role(self, guild: discord.Guild, role: discord.Role):
@@ -60,7 +70,8 @@ class MemoryCache:
         guild_temp_actions = self.temp_actions.get(guild.id)
         if guild_temp_actions is None:
             guild_temp_actions = await self.data.guild(guild).temporary_warns.all()
-            self.temp_actions[guild.id] = guild_temp_actions
+            if guild_temp_actions:
+                self.temp_actions[guild.id] = guild_temp_actions
         if member is None:
             return guild_temp_actions
         return guild_temp_actions.get(member.id)
@@ -82,6 +93,52 @@ class MemoryCache:
     async def bulk_remove_temp_action(self, guild: discord.Guild, members: list):
         members = [x.id for x in members]
         warns = await self.get_temp_action(guild)
-        warns = {x: y for x, y in warns.items() if x not in members}
+        warns = {x: y for x, y in warns.items() if int(x) not in members}
         await self.data.guild(guild).temporary_warns.set(warns)
         self.temp_actions[guild.id] = warns
+
+    def get_automod_enabled(self, guild: discord.Guild):
+        return guild.id in self.automod_enabled
+
+    async def add_automod_enabled(self, guild: discord.Guild):
+        self.automod_enabled.append(guild.id)
+        await self.data.guild(guild).automod.enabled.set(True)
+
+    async def remove_automod_enabled(self, guild: discord.Guild):
+        self.automod_enabled.remove(guild.id)
+        await self.data.guild(guild).automod.enabled.set(False)
+
+    async def get_automod_regex(self, guild: discord.Guild):
+        automod_regex = self.automod_regex.get(guild.id)
+        if not automod_regex:
+            automod_regex = await self.data.guild(guild).automod.regex()
+            for name, regex in automod_regex.items():
+                pattern = re.compile(regex["regex"])
+                automod_regex[name] = pattern
+            if automod_regex:
+                self.automod_regex[guild.id] = automod_regex
+        return automod_regex
+
+    async def add_automod_regex(
+        self,
+        guild: discord.Guild,
+        name: str,
+        regex: re.Pattern,
+        level: int,
+        time: str,
+        reason: str,
+    ):
+        await self.data.guild(guild).automod.regex.set_raw(
+            name, value={"regex": regex.pattern, "level": level, "time": time, "reason": reason}
+        )
+        if guild.id not in self.automod_regex:
+            self.automod_regex[guild.id] = {name: regex}
+        else:
+            self.automod_regex[guild.id][name] = regex
+
+    async def remove_automod_regex(self, guild: discord.Guild, name: str):
+        await self.data.guild(guild).automod.regex.clear_raw(name)
+        try:
+            del self.automod_regex[guild.id][name]
+        except KeyError:
+            pass

--- a/warnsystem/cache.py
+++ b/warnsystem/cache.py
@@ -1,0 +1,81 @@
+import discord
+import logging
+import contextlib
+
+from typing import Mapping, Optional
+from redbot.core import Config
+
+from .abc import MixinMeta
+
+log = logging.getLogger("laggron.warnsystem")
+
+
+class MemoryCache(MixinMeta):
+    """
+    This class is used to store most used Config values and reduce calls for optimization.
+    See Github issue #49
+    """
+
+    async def _debug_info(self) -> str:
+        """
+        Compare the cached data to the Config data. Text is logged (INFO) then returned.
+        
+        This calls a huge part of the Config database and will not load it into the cache.
+        """
+        config_data = await self.data.all_guilds()
+        mute_roles_cached = len(self.mute_roles)
+        mute_roles = sum((x for x in config_data.values() if x["mute_role"] is not None))
+        guild_temp_actions_cached = len(self.temp_actions)
+        guild_temp_actions = len(config_data["temporary_warns"])
+        temp_actions_cached = sum(len(x) for x in self.temp_actions.values())
+        temp_actions = sum((len(x["temporary_warns"]) for x in config_data.values()))
+        text = (
+            f"Debug info requested\n"
+            f"{mute_roles_cached}/{mute_roles} mute roles loaded in cache.\n"
+            f"{guild_temp_actions_cached}/{guild_temp_actions} guilds with temp actions loaded in cache.\n"
+            f"{temp_actions_cached}/{temp_actions} temporary actions loaded in cache."
+        )
+        log.info(text)
+        return text
+
+    async def get_mute_role(self, guild: discord.Guild):
+        role_id = self.mute_roles.get(guild.id)
+        if role_id:
+            return role_id
+        role_id = await self.data.guild(guild).mute_role()
+        self.mute_roles[guild.id] = role_id
+        return role_id
+
+    async def update_mute_role(self, guild: discord.Guild, role: discord.Role):
+        await self.data.guild(guild).mute_role.set(role.id)
+        self.mute_roles[guild.id] = role.id
+
+    async def get_temp_action(self, guild: discord.Guild, member: Optional[discord.Member] = None):
+        guild_temp_actions = self.temp_actions.get(guild.id)
+        if guild_temp_actions is None:
+            guild_temp_actions = await self.data.guild(guild).temporary_warns.all()
+            self.temp_actions[guild.id] = guild_temp_actions
+        if member is None:
+            return guild_temp_actions
+        return guild_temp_actions.get(member.id)
+
+    async def add_temp_action(self, guild: discord.Guild, member: discord.Member, data: dict):
+        await self.data.guild(guild).temporary_warns.set_raw(member.id, value=data)
+        try:
+            guild_temp_actions = self.temp_actions[guild.id]
+        except KeyError:
+            self.temp_actions[guild.id] = {member.id: data}
+        else:
+            guild_temp_actions[member.id] = data
+
+    async def remove_temp_action(self, guild: discord.Guild, member: discord.Member):
+        await self.data.guild(guild).temporary_warns.clear_raw(member.id)
+        with contextlib.suppress(KeyError):
+            del self.temp_actions[guild.id][member.id]
+
+    async def bulk_remove_temp_action(self, guild: discord.Guild, members: list):
+        members = [x.id for x in members]
+        warns = await self.get_temp_action(guild)
+        warns = {x: y for x, y in warns.items() if x not in members}
+        await self.data.guild(guild).temporary_warns.set(warns)
+        self.temp_actions[guild.id] = warns

--- a/warnsystem/cache.py
+++ b/warnsystem/cache.py
@@ -4,17 +4,23 @@ import contextlib
 
 from typing import Mapping, Optional
 from redbot.core import Config
-
-from .abc import MixinMeta
+from redbot.core.bot import Red
 
 log = logging.getLogger("laggron.warnsystem")
 
 
-class MemoryCache(MixinMeta):
+class MemoryCache:
     """
     This class is used to store most used Config values and reduce calls for optimization.
     See Github issue #49
     """
+
+    def __init__(self, bot: Red, config: Config):
+        self.bot = bot
+        self.data = config
+
+        self.mute_roles = {}
+        self.temp_actions = {}
 
     async def _debug_info(self) -> str:
         """

--- a/warnsystem/converters.py
+++ b/warnsystem/converters.py
@@ -1,17 +1,19 @@
 import argparse
 import discord
 import re
+import logging
 
 from dateutil import parser
 from discord.ext.commands.converter import RoleConverter, MemberConverter
 
-from redbot.core.commands import BadArgument
+from redbot.core.commands import BadArgument, Converter, Context
 from redbot.core.commands.converter import TimedeltaConverter
 from redbot.core.i18n import Translator
 
 from .api import UnavailableMember
 
 _ = Translator("WarnSystem", __file__)
+log = logging.getLogger("laggron.warnsystem")
 
 
 # credit to mikeshardmind (Sinbad) for parse_time
@@ -440,3 +442,25 @@ class AdvancedMemberSelect:
             self.confirm = args.confirm
             self.members, self.unavailable_members = await self.process_arguments(args)
             return self
+
+
+class ValidRegex(Converter):
+    """
+    This will check to see if the provided regex pattern is valid
+
+    Guidance code on how to do this from:
+    https://github.com/Rapptz/discord.py/blob/rewrite/discord/ext/commands/converter.py#L85
+    https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/cogs/mod/mod.py#L24
+
+    This function (and a lot of code related to regex) is made by TrustyJAID
+    https://github.com/TrustyJAID/Trusty-cogs/blob/master/retrigger/converters.py#L240
+    """
+
+    async def convert(self, ctx: Context, argument: str) -> str:
+        try:
+            result = re.compile(argument)
+        except Exception as e:
+            log.error("Retrigger conversion error")
+            err_msg = _("`{arg}` is not a valid regex pattern. {e}").format(arg=argument, e=e)
+            raise BadArgument(err_msg)
+        return result

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -229,16 +229,15 @@ class SettingsMixin(MixinMeta):
                 cases = []
                 for case in [y for x, y in logs.items() if x.startswith("case")]:
                     level = {"Simple": 1, "Kick": 3, "Softban": 4, "Ban": 5}.get(case["level"], 1)
-                    timestamp = datetime.strptime(case["timestamp"], "%d %b %Y %H:%M").strftime(
-                        "%a %d %B %Y %H:%M:%S"
-                    )
+                    timestamp = datetime.strptime(case["timestamp"], "%d %b %Y %H:%M").timestamp()
                     cases.append(
                         {
                             "level": level,
                             "author": "Unknown",
                             "reason": case["reason"],
-                            "time": timestamp,  # only day of the week missing
+                            "time": timestamp,
                             "duration": None,
+                            "roles": [],
                         }
                     )
                     total_cases += 1
@@ -573,7 +572,7 @@ class SettingsMixin(MixinMeta):
 
             # collect data and make strings
             all_data = await self.data.guild(guild).all()
-            modlog_channels = await self.get_modlog_channel(guild, "all")
+            modlog_channels = await self.api.get_modlog_channel(guild, "all")
             channels = ""
             for key, channel in dict(modlog_channels).items():
                 if not channel:

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -491,7 +491,7 @@ class SettingsMixin(MixinMeta):
                 ).format(bot_role=guild.me.top_role.name)
             )
         else:
-            await self.data.guild(guild).mute_role.set(role.id)
+            await self.cache.update_mute_role(role)
             await ctx.send(_("The new mute role was successfully set!"))
 
     @warnset.command(name="reinvite")

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -490,7 +490,7 @@ class SettingsMixin(MixinMeta):
                 ).format(bot_role=guild.me.top_role.name)
             )
         else:
-            await self.cache.update_mute_role(role)
+            await self.cache.update_mute_role(guild, role)
             await ctx.send(_("The new mute role was successfully set!"))
 
     @warnset.command(name="refreshmuterole")

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -456,7 +456,7 @@ class SettingsMixin(MixinMeta):
                 )
                 return
             async with ctx.typing():
-                fails = await self.api.maybe_create_mute_role(guild)
+                fails = await self.maybe_create_mute_role(guild)
                 my_position = guild.me.top_role.position
                 if fails is False:
                     await ctx.send(
@@ -573,7 +573,7 @@ class SettingsMixin(MixinMeta):
 
             # collect data and make strings
             all_data = await self.data.guild(guild).all()
-            modlog_channels = await self.api.get_modlog_channel(guild, "all")
+            modlog_channels = await self.get_modlog_channel(guild, "all")
             channels = ""
             for key, channel in dict(modlog_channels).items():
                 if not channel:

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -398,6 +398,36 @@ class SettingsMixin(MixinMeta):
             )
         )
 
+    @warnset.command(name="detectmanual")
+    async def warnset_detectmanual(self, ctx: commands.Context, enable: bool = None):
+        """
+        Defines if the bot should log manual bans to WarnSystem.
+
+        If enabled, manually banning a member will make the bot log the action in the modlog and\
+save it, as if it was performed with WarnSystem. **However, the member will not receive a DM**.
+        
+        Invoke the command without arguments to get the current status.
+        """
+        guild = ctx.guild
+        current = await self.data.guild(guild).log_manual()
+        if enable is None:
+            await ctx.send(
+                _(
+                    "The bot currently {detect} manual bans. If you want to change this, "
+                    "type `{prefix}warnset detectmanual {opposite}`."
+                ).format(
+                    detect=_("detects") if current else _("doesn't detect"),
+                    opposite=not current,
+                    prefix=ctx.clean_prefix,
+                )
+            )
+        elif enable:
+            await self.data.guild(guild).log_manual.set(True)
+            await ctx.send(_("Done. The bot will now listen for manual bans and log them."))
+        else:
+            await self.data.guild(guild).log_manual.set(False)
+            await ctx.send(_("Done. The bot won't listen for manual bans anymore."))
+
     @warnset.command(name="hierarchy")
     async def warnset_hierarchy(self, ctx: commands.Context, enable: bool = None):
         """
@@ -584,8 +614,7 @@ channels, and prevented from talking in all voice channels.
             return text
 
         text = _("Successfully checked all channels, {len}/{total} were edited.\n\n").format(
-            len=count - len(perms_failed) - len(other_failed),
-            total=count,
+            len=count - len(perms_failed) - len(other_failed), total=count,
         )
         if perms_failed:
             text += _(
@@ -703,6 +732,7 @@ channels, and prevented from talking in all voice channels.
             show_mod = _("Enabled") if all_data["show_mod"] else _("Disabled")
             update_mute = _("Enabled") if all_data["update_mute"] else _("Disabled")
             remove_roles = _("Enabled") if all_data["remove_roles"] else _("Disabled")
+            manual_bans = _("Enabled") if all_data["log_manual"] else _("Disabled")
             bandays = _("Softban: {softban}\nBan: {ban}").format(
                 softban=all_data["bandays"]["softban"], ban=all_data["bandays"]["ban"]
             )
@@ -768,6 +798,7 @@ channels, and prevented from talking in all voice channels.
             embeds[0].add_field(name=_("Respect hierarchy"), value=hierarchy)
             embeds[0].add_field(name=_("Reinvite unbanned members"), value=reinvite)
             embeds[0].add_field(name=_("Show responsible moderator"), value=show_mod)
+            embeds[0].add_field(name=_("Detect manual bans"), value=manual_bans)
             embeds[0].add_field(name=_("Update new channels for mute role"), value=update_mute)
             embeds[0].add_field(name=_("Remove roles on mute"), value=remove_roles)
             embeds[0].add_field(name=_("Days of messages to delete"), value=bandays)

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -18,7 +18,7 @@ from redbot.core.utils.chat_formatting import pagify
 
 from . import errors
 from .api import API, UnavailableMember
-from .automod import AutoModMixin
+from .automod import AutomodMixin
 from .cache import MemoryCache
 from .converters import AdvancedMemberSelect
 from .settings import SettingsMixin
@@ -68,7 +68,7 @@ class CompositeMetaClass(type(commands.Cog), type(ABC)):
 
 
 @cog_i18n(_)
-class WarnSystem(SettingsMixin, AutoModMixin, BaseCog, metaclass=CompositeMetaClass):
+class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaClass):
     """
     An alternative to the Red core moderation system, providing a different system of moderation\
     similar to Dyno.
@@ -132,6 +132,10 @@ class WarnSystem(SettingsMixin, AutoModMixin, BaseCog, metaclass=CompositeMetaCl
         },
         "url": None,  # URL set for the title of all embeds
         "temporary_warns": {},  # list of temporary warns (need to unmute/unban after some time)
+        "automod": {  # everything related to auto moderation
+            "enabled": False,
+            "regex": {},  # all regex expressions
+        },
     }
     default_custom_member = {"x": []}  # cannot set a list as base group
 

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -192,6 +192,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         "automod": {  # everything related to auto moderation
             "enabled": False,
             "regex": {},  # all regex expressions
+            "warnings": [],  # all automatic warns
         },
     }
     default_custom_member = {"x": []}  # cannot set a list as base group
@@ -1353,14 +1354,8 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
             return
         if not (mute_role in before.roles and mute_role not in after.roles):
             return
-        to_remove = []
-        warns = await self.cache.get_temp_action(guild)
-        for member, data in warns.items():
-            if data["level"] == 5 or member != after.id:
-                continue
-            to_remove.append(member)
-        if to_remove:
-            await self.cache.bulk_remove_temp_action(guild, to_remove)
+        if after.id in self.cache.temp_actions:
+            await self.cache.remove_temp_action(guild, after)
             log.info(
                 f"[Guild {guild.id}] The temporary mute of member {after} (ID: {after.id}) "
                 "was ended due to a manual unmute (role removed)."

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1301,9 +1301,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         """
         Unban a member banned with WarnSystem.
 
-        If the reinvite setting is enabled, the bot will try to reinvite the member in DM, with\
-        the optional given reason.
-
         *wsunban = WarnSystem unban. Feel free to add an alias.*
         """
         guild = ctx.guild

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -888,7 +888,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
                 )
             embed.add_field(name=_("Reason"), value=case["reason"], inline=False),
             embed.timestamp = self.api._get_datetime(case["time"])
-            embed.color = await self.data.guild(ctx.guild).colors.get_raw(level)
+            embed.colour = await self.data.guild(ctx.guild).colors.get_raw(level)
             embeds.append(embed)
 
         controls = {"⬅": menus.prev_page, "❌": menus.close_menu, "➡": menus.next_page}

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -991,6 +991,33 @@ class WarnSystem(SettingsMixin, BaseCog, metaclass=CompositeMetaClass):
         ]
         await menus.menu(ctx=ctx, pages=pages, controls=menus.DEFAULT_CONTROLS, timeout=60)
 
+    @commands.command()
+    @checks.mod()
+    async def wsunmunte(self, ctx: commands.Context, member: discord.Member, *, reason: str):
+        """
+        Unmute a member muted with WarnSystem.
+
+        If the member's roles were removed, they will be granted back.
+        Reason is optional and will be associated to the latest level 2 warn.
+
+        *wsunmute = WarnSystem unmute. Feel free to add an alias.*
+        """
+        pass
+
+    @commands.command()
+    @checks.mod()
+    async def wsunban(self, ctx: commands.Context, member: UnavailableMember, *, reason: str):
+        """
+        Unban a member banned with WarnSystem.
+
+        If the reinvite setting is enabled, the bot will try to reinvite the member in DM, with\
+        the optional given reason.
+        Reason is optional and will be associated to the latest level 5 warn.
+
+        *wsunban = WarnSystem unban. Feel free to add an alias.*
+        """
+        pass
+
     @commands.command(hidden=True)
     async def warnsysteminfo(self, ctx):
         """

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -871,6 +871,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
             moderator = ctx.guild.get_member(case["author"])
             moderator = "ID: " + str(case["author"]) if not moderator else moderator.mention
 
+            time = self.api._get_datetime(case["time"])
             embed = discord.Embed(
                 description=_("Case #{number} informations").format(number=i + 1)
             )
@@ -880,14 +881,16 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
             )
             embed.add_field(name=_("Moderator"), value=moderator, inline=True)
             if case["duration"]:
+                duration = self.api._get_timedelta(case["duration"])
                 embed.add_field(
                     name=_("Duration"),
                     value=_("{duration}\n(Until {date})").format(
-                        duration=case["duration"], date=case["until"]
+                        duration=self.api._format_timedelta(duration),
+                        date=self.api._format_datetime(time + duration),
                     ),
                 )
             embed.add_field(name=_("Reason"), value=case["reason"], inline=False),
-            embed.timestamp = self.api._get_datetime(case["time"])
+            embed.timestamp = time
             embed.colour = await self.data.guild(ctx.guild).colors.get_raw(level)
             embeds.append(embed)
 
@@ -1190,8 +1193,10 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
                 "Date:      {time}\n"
             ).format(number=i, **warn)
             if warn["duration"]:
+                duration = self.api._get_timedelta(warn["duration"])
                 text += _("Duration:  {duration}\nUntil:     {until}\n").format(
-                    duration=warn["duration"], until=warn["until"]
+                    duration=self.api._format_timedelta(duration),
+                    until=self.api._format_datetime(warn["time"] + duration),
                 )
             text += "\n\n"
             full_text = text + full_text

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -199,7 +199,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
                 "delay_before_action": 60,  # if triggered twice within this delay, take action
                 "warn": {  # data of the warn
                     "level": 1,
-                    "reason": "Spamming in {channel.mention}.",
+                    "reason": "Sending messages too fast!",
                     "time": None,
                 },
             },
@@ -1237,7 +1237,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         Unmute a member muted with WarnSystem.
 
         If the member's roles were removed, they will be granted back.
-        Reason is optional and will be associated to the latest level 2 warn.
 
         *wsunmute = WarnSystem unmute. Feel free to add an alias.*
         """
@@ -1304,7 +1303,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
 
         If the reinvite setting is enabled, the bot will try to reinvite the member in DM, with\
         the optional given reason.
-        Reason is optional and will be associated to the latest level 5 warn.
 
         *wsunban = WarnSystem unban. Feel free to add an alias.*
         """

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1353,7 +1353,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         to_remove = []
         warns = await self.cache.get_temp_action(guild)
         for member, data in warns.items():
-            if data["level"] == 5 or data["member"] != after.id:
+            if data["level"] == 5 or member != after.id:
                 continue
             to_remove.append(member)
         if to_remove:

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -191,6 +191,17 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         "temporary_warns": {},  # list of temporary warns (need to unmute/unban after some time)
         "automod": {  # everything related to auto moderation
             "enabled": False,
+            "antispam": {
+                "enabled": False,
+                "max_messages": 5,  # maximum number of messages allowed within the delay
+                "delay": 2,  # in seconds
+                "delay_before_action": 60,  # if triggered twice within this delay, take action
+                "warn": {  # data of the warn
+                    "level": 1,
+                    "reason": "Spamming in {channel.mention}.",
+                    "time": None,
+                },
+            },
             "regex": {},  # all regex expressions
             "warnings": [],  # all automatic warns
         },
@@ -1427,3 +1438,4 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
 
         # stop checking for unmute and unban
         self.task.cancel()
+        self.api.disable_automod()

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1183,6 +1183,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         guild = ctx.guild
         full_text = ""
         warns = await self.api.get_all_cases(guild)
+        if not warns:
+            await ctx.send(_("No warnings have been issued in this server yet."))
+            return
         for i, warn in enumerate(warns, start=1):
             text = _(
                 "--- Case {number} ---\n"

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -147,7 +147,7 @@ class WarnSystem(SettingsMixin, BaseCog, metaclass=CompositeMetaClass):
         self.task = bot.loop.create_task(self.api._loop_task())
         self._init_logger()
 
-    __version__ = "1.2.5"
+    __version__ = "1.3.0"
     __author__ = ["retke (El Laggron)"]
 
     def _init_logger(self):


### PR DESCRIPTION
<!--
Hello and thanks for contributing to Laggron's Dumb Cogs
Before submitting your PR, please fill out the following questions
To tick a case, place an x between the brackets.
-->

## Pull request type

- [x] Feature addition
- [x] Bug fix
- [x] Grammar or minor corrections

## Description of the changes

Third major update of WarnSystem, ~~not much planned for now, waiting for your suggestions~~ actually yes, automod is a big thing, but I'm still waiting for your suggestions.

### Automod

This is going to be the main addition of this update, automatic warnings based on member's actions

- [x] fc45752 Base + Regex triggers
- [x] 925168d Trigger based on recent warnings (ex: 3 warns in 24h -> kick) (#65)
- [x] 2bbf049 Trigger based on message spam (#66)

Please leave suggestions for more possible triggers with automod.

### Other main new features

- [x] 216de1f Cache system. Brings better performance and more bugs :NotLikeThis: Resolves #67 
- [x] a0799c9 915bb83 Add `[p]wsunmute` and `[p]wsunban` commands
- [x] f959f75 Option to clear entire modlog of user with `[p]warnings`
- [x] 665f391 Add `[p]warnset refreshmuterole` command to check all guild's channels permissions and update those with incorrect permissions for the mute role (includes voice mute).
- [x] 5676353 Default permissions for mute role will also include voice mute. You can use the command above to update your server. Resolves #74
- [ ] ~~Add `[p]note` command to write something in someone's modlog without any DM. Not counted as a warning. Suggestion by @entchen66~~ Would require a lot of work given the code's current structure, maybe for later.
- [ ] ~~Give unique case numbers to all warnings for an entire guild (like core's modlog). Suggested by @FixedThink~~ Same as above, the current structure would either require major changes, or the past modlogs would simply not have any number assigned.
- [x] ce600d9 Detect manual ~~kicks and~~ bans, and optionally log them. Suggested by @FixedThink

### Minor features

- [x] 644e1fd Edit the messages in modlog when reason is edited
- [x] 263207e Redesign settings
- [x] a7c1a92 Show the last 10 warnings on the first page when using `[p]warnings`. [Click here for a preview.](https://i.imgur.com/TUQ9et0.png)
- [x] 147a7da Use `embed.timestamp` to fix timezone issues with embeds. Suggested by @FixedThink
- [x] 3278b81 Correct grammar errors revealed by @FixedThink

Please leave your suggestions below