### PR TITLE
Remove usage of `loop` arg in call to `start_adding_reactions`

### DIFF
--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -189,7 +189,7 @@ class InstantCommands(BaseCog):
             "Would you like to replace it?"
         )
         pred = ReactionPredicate.yes_or_no(msg, ctx.author)
-        start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS, loop=ctx.bot.loop)
+        start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
         try:
             await self.bot.wait_for("reaction_add", check=pred, timeout=30)
         except asyncio.TimeoutError:

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -75,7 +75,7 @@ class InstantCommands(BaseCog):
         self._init_logger()
 
     __author__ = ["retke (El Laggron)"]
-    __version__ = "1.1.0"
+    __version__ = "1.1.1"
 
     def _init_logger(self):
         log_format = logging.Formatter(


### PR DESCRIPTION
## Pull request type

- [ ] Feature addition
- [x] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes

`loop` arg have been deprecated in Red and is pending removal.