### PR TITLE
[InstantCommands] Fix listener names that are used on cog load

### DIFF
--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -138,7 +138,7 @@ class InstantCommands(BaseCog):
         else:
             if not isinstance(function, Listener):
                 function = Listener(function, function.__name__)
-            self.bot.add_listener(function.func)
+            self.bot.add_listener(function.func, name=function.name)
             self.listeners[function.func.__name__] = (function.id, function.name)
             if function.name != function.func.__name__:
                 log.debug(

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -75,7 +75,7 @@ class InstantCommands(BaseCog):
         self._init_logger()
 
     __author__ = ["retke (El Laggron)"]
-    __version__ = "1.1.1"
+    __version__ = "1.1.2"
 
     def _init_logger(self):
         log_format = logging.Formatter(


### PR DESCRIPTION
## Pull request type

- [ ] Feature addition
- [x] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes
This fixes a bug that made InstantCommands use incorrect listener name because it ignored the `Listener.name`.
