### PR TITLE
Migrate loggers to new pip package laggron_utils

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install Red-DiscordBot
+          python -m pip install git+https://github.com/retke/laggron-utils
           python -m pip install python-dateutil==2.8.1
       - name: Compile all
         run: |
@@ -47,6 +48,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install Red-DiscordBot
+          python -m pip install git+https://github.com/retke/laggron-utils
           python -m pip install python-dateutil==2.8.1
           python -m pip install black==19.10b0
       - name: Checking style

--- a/codmw/__init__.py
+++ b/codmw/__init__.py
@@ -1,7 +1,18 @@
 import logging
+import importlib.util
 from .codmw import CODMW
 
-log = logging.getLogger("laggron.codmw")
+from redbot.core.errors import CogLoadError
+
+if not importlib.util.find_spec("laggron_utils"):
+    raise CogLoadError(
+        "You need the `laggron_utils` package for any cog from Laggron's Dumb Cogs. "
+        "Use the command `[p]pipinstall git+https://github.com/retke/Laggron-utils.git` "
+        "or type `pip3 install -U git+https://github.com/retke/Laggron-utils.git` in the "
+        "terminal to install the library."
+    )
+
+log = logging.getLogger("red.laggron.codmw")
 
 
 def setup(bot):

--- a/codmw/__init__.py
+++ b/codmw/__init__.py
@@ -3,6 +3,7 @@ import importlib.util
 from .codmw import CODMW
 
 from redbot.core.errors import CogLoadError
+from laggron_utils import init_logger
 
 if not importlib.util.find_spec("laggron_utils"):
     raise CogLoadError(
@@ -16,6 +17,7 @@ log = logging.getLogger("red.laggron.codmw")
 
 
 def setup(bot):
+    init_logger(log, CODMW.__class__.__name__)
     n = CODMW(bot)
     bot.add_cog(n)
     log.debug("Cog successfully loaded on the instance.")

--- a/codmw/api_wrapper.py
+++ b/codmw/api_wrapper.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 from datetime import datetime
 from typing import Optional
 
-log = logging.getLogger("laggron.codmw")
+log = logging.getLogger("red.laggron.codmw")
 BASE_URL = "https://my.callofduty.com/api/papi-client/"
 
 

--- a/codmw/codmw.py
+++ b/codmw/codmw.py
@@ -13,7 +13,6 @@ from redbot.core.data_manager import cog_data_path
 from .api_wrapper import Client, Forbidden, NotFound
 
 log = logging.getLogger("red.laggron.codmw")
-init_logger(log, "CODMW")
 _ = Translator("CODMW", __file__)
 
 GAMEMODES_MAPPING = {

--- a/codmw/info.json
+++ b/codmw/info.json
@@ -12,7 +12,7 @@
     "install_msg": "Thank you for installing the codmw cog.\nType `[p]help cod` for a quick overview of the commands.",
     "required_cogs": {},
     "requirements": [
-        "laggron_utils"
+        "git+https://github.com/retke/laggron-utils"
     ],
     "short": "Call of Duty MW stats.",
     "tags": [

--- a/codmw/info.json
+++ b/codmw/info.json
@@ -1,4 +1,3 @@
-
 {
     "author": [
         "retke (El Laggron)"
@@ -12,7 +11,9 @@
     "hidden": false,
     "install_msg": "Thank you for installing the codmw cog.\nType `[p]help cod` for a quick overview of the commands.",
     "required_cogs": {},
-    "requirements": [],
+    "requirements": [
+        "laggron_utils"
+    ],
     "short": "Call of Duty MW stats.",
     "tags": [
         "modernwarfare",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx_autodoc_napoleon_typehints==2.1.6
 sphinx_rtd_theme==0.4.3
 Red-DiscordBot
 python-dateutil==2.8.1
+git+https://github.com/retke/laggron-utils

--- a/instantcmd/__init__.py
+++ b/instantcmd/__init__.py
@@ -4,6 +4,7 @@ from .instantcmd import InstantCommands
 
 from redbot.core.data_manager import cog_data_path
 from redbot.core.errors import CogLoadError
+from laggron_utils import init_logger
 
 if not importlib.util.find_spec("laggron_utils"):
     raise CogLoadError(
@@ -56,6 +57,7 @@ async def ask_reset(bot, commands):
 
 
 async def setup(bot):
+    init_logger(log, InstantCommands.__class__.__name__, "instantcmd")
     n = InstantCommands(bot)
     if not await n.data.updated_body():
         commands = await n.data.commands()

--- a/instantcmd/__init__.py
+++ b/instantcmd/__init__.py
@@ -1,8 +1,19 @@
 import logging
-from redbot.core.data_manager import cog_data_path
+import importlib.util
 from .instantcmd import InstantCommands
 
-log = logging.getLogger("laggron.instantcmd")
+from redbot.core.data_manager import cog_data_path
+from redbot.core.errors import CogLoadError
+
+if not importlib.util.find_spec("laggron_utils"):
+    raise CogLoadError(
+        "You need the `laggron_utils` package for any cog from Laggron's Dumb Cogs. "
+        "Use the command `[p]pipinstall git+https://github.com/retke/Laggron-utils.git` "
+        "or type `pip3 install -U git+https://github.com/retke/Laggron-utils.git` in the "
+        "terminal to install the library."
+    )
+
+log = logging.getLogger("red.laggron.instantcmd")
 
 
 async def ask_reset(bot, commands):

--- a/instantcmd/info.json
+++ b/instantcmd/info.json
@@ -12,7 +12,7 @@
     "install_msg": "Thanks for installing instantcmd. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/\nEverything you need to know about setting up the cog is here.\n\nPlease keep in mind that you must know Python and discord.py for that cog. Try to create normal cogs if you don't already know how it works.",
     "required_cogs": {},
     "requirements": [
-        "laggron_utils"
+        "git+https://github.com/retke/laggron-utils"
     ],
     "short": "Instant command maker",
     "tags": [

--- a/instantcmd/info.json
+++ b/instantcmd/info.json
@@ -11,7 +11,9 @@
     "hidden": false,
     "install_msg": "Thanks for installing instantcmd. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/\nEverything you need to know about setting up the cog is here.\n\nPlease keep in mind that you must know Python and discord.py for that cog. Try to create normal cogs if you don't already know how it works.",
     "required_cogs": {},
-    "requirements": [],
+    "requirements": [
+        "laggron_utils"
+    ],
     "short": "Instant command maker",
     "tags": [
         "command",

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -10,19 +10,19 @@ import os
 import sys
 import redbot
 
+from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
+
 from redbot.core import commands
 from redbot.core import checks
 from redbot.core import Config
-from redbot.core.data_manager import cog_data_path
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.chat_formatting import pagify
 
 from .utils import Listener
 
-log = logging.getLogger("laggron.instantcmd")
-log.setLevel(logging.DEBUG)
-
+log = logging.getLogger("red.laggron.instantcmd")
+init_logger(log, "InstantCommands", "instantcmd")
 BaseCog = getattr(commands, "Cog", object)
 
 # Red 3.0 backwards compatibility, thanks Sinbad
@@ -79,36 +79,9 @@ class InstantCommands(BaseCog):
         }
         # resume all commands and listeners
         bot.loop.create_task(self.resume_commands())
-        self._init_logger()
 
     __author__ = ["retke (El Laggron)"]
     __version__ = "1.2.0"
-
-    def _init_logger(self):
-        log_format = logging.Formatter(
-            f"%(asctime)s %(levelname)s {self.__class__.__name__}: %(message)s",
-            datefmt="[%d/%m/%Y %H:%M]",
-        )
-        # logging to a log file
-        # file is automatically created by the module, if the parent foler exists
-        cog_path = cog_data_path(self)
-        if cog_path.exists():
-            log_path = cog_path / f"{os.path.basename(__file__)[:-3]}.log"
-            file_handler = logging.FileHandler(log_path)
-            file_handler.setLevel(logging.DEBUG)
-            file_handler.setFormatter(log_format)
-            log.addHandler(file_handler)
-
-        # stdout stuff
-        stdout_handler = logging.StreamHandler()
-        stdout_handler.setFormatter(log_format)
-        # if --debug flag is passed, we also set our debugger on debug mode
-        if logging.getLogger("red").isEnabledFor(logging.DEBUG):
-            stdout_handler.setLevel(logging.DEBUG)
-        else:
-            stdout_handler.setLevel(logging.INFO)
-        log.addHandler(stdout_handler)
-        self.stdout_handler = stdout_handler
 
     # def get_config_identifier(self, name):
     # """
@@ -430,11 +403,11 @@ cog at this point.
                 "I need the `Add reactions` and `Manage messages` in the "
                 "current channel if you want to use this command."
             )
-        log.removeHandler(self.stdout_handler)  # remove console output since red also handle this
-        log.error(
-            f"Exception in command '{ctx.command.qualified_name}'.\n\n", exc_info=error.original
-        )
-        log.addHandler(self.stdout_handler)  # re-enable console output for warnings
+        with DisabledConsoleOutput(log):
+            log.error(
+                f"Exception in command '{ctx.command.qualified_name}'.\n\n",
+                exc_info=error.original,
+            )
 
     # correctly unload the cog
     def __unload(self):
@@ -449,7 +422,7 @@ cog at this point.
 
             # remove all handlers from the logger, this prevents adding
             # multiple times the same handler if the cog gets reloaded
-            log.handlers = []
+            close_logger(log)
 
         # I am forced to put everything in an async function to execute the remove_commands
         # function, and then remove the handlers. Using loop.create_task on remove_commands only

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -80,7 +80,7 @@ class InstantCommands(BaseCog):
         bot.loop.create_task(self.resume_commands())
 
     __author__ = ["retke (El Laggron)"]
-    __version__ = "1.2.0"
+    __version__ = "1.2.1"
 
     # def get_config_identifier(self, name):
     # """

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -10,7 +10,7 @@ import os
 import sys
 import redbot
 
-from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
+from laggron_utils.logging import close_logger, DisabledConsoleOutput
 
 from redbot.core import commands
 from redbot.core import checks
@@ -22,7 +22,6 @@ from redbot.core.utils.chat_formatting import pagify
 from .utils import Listener
 
 log = logging.getLogger("red.laggron.instantcmd")
-init_logger(log, "InstantCommands", "instantcmd")
 BaseCog = getattr(commands, "Cog", object)
 
 # Red 3.0 backwards compatibility, thanks Sinbad

--- a/roleinvite/__init__.py
+++ b/roleinvite/__init__.py
@@ -1,7 +1,18 @@
 import logging
+import importlib.util
 from .roleinvite import RoleInvite
 
-log = logging.getLogger("laggron.roleinvite")
+from redbot.core.errors import CogLoadError
+
+if not importlib.util.find_spec("laggron_utils"):
+    raise CogLoadError(
+        "You need the `laggron_utils` package for any cog from Laggron's Dumb Cogs. "
+        "Use the command `[p]pipinstall git+https://github.com/retke/Laggron-utils.git` "
+        "or type `pip3 install -U git+https://github.com/retke/Laggron-utils.git` in the "
+        "terminal to install the library."
+    )
+
+log = logging.getLogger("red.laggron.roleinvite")
 
 
 async def setup(bot):

--- a/roleinvite/__init__.py
+++ b/roleinvite/__init__.py
@@ -3,6 +3,7 @@ import importlib.util
 from .roleinvite import RoleInvite
 
 from redbot.core.errors import CogLoadError
+from laggron_utils import init_logger
 
 if not importlib.util.find_spec("laggron_utils"):
     raise CogLoadError(
@@ -16,6 +17,7 @@ log = logging.getLogger("red.laggron.roleinvite")
 
 
 async def setup(bot):
+    init_logger(log, RoleInvite.__class__.__name__)
     n = RoleInvite(bot)
     bot.add_cog(n)
     log.debug("Cog successfully loaded on the instance.")

--- a/roleinvite/api.py
+++ b/roleinvite/api.py
@@ -1,10 +1,12 @@
 import discord
 import logging
 
-from .roleinvite import _  # translator
+from redbot.core.i18n import Translator
+
 from . import errors
 
-log = logging.getLogger("laggron.roleinvite")
+log = logging.getLogger("red.laggron.roleinvite")
+_ = Translator("RoleInvite", __file__)
 
 
 class API:

--- a/roleinvite/info.json
+++ b/roleinvite/info.json
@@ -11,7 +11,9 @@
     "hidden": false,
     "install_msg": "Thanks for installing roleinvite. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/roleinvite.html\nEverything you need to know about setting up the cog is here.\nFor a quick guide, type `[p]help RoleInvite`, just keep in mind that the bot needs the `Manage server` and the `Add roles` permissions.",
     "required_cogs": {},
-    "requirements": [],
+    "requirements": [
+        "laggron_utils"
+    ],
     "short": "Autorole based on server's invites",
     "tags": [
         "autorole",

--- a/roleinvite/info.json
+++ b/roleinvite/info.json
@@ -12,7 +12,7 @@
     "install_msg": "Thanks for installing roleinvite. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/roleinvite.html\nEverything you need to know about setting up the cog is here.\nFor a quick guide, type `[p]help RoleInvite`, just keep in mind that the bot needs the `Manage server` and the `Add roles` permissions.",
     "required_cogs": {},
     "requirements": [
-        "laggron_utils"
+        "git+https://github.com/retke/laggron-utils"
     ],
     "short": "Autorole based on server's invites",
     "tags": [

--- a/roleinvite/roleinvite.py
+++ b/roleinvite/roleinvite.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 import discord
 
-from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
+from laggron_utils.logging import close_logger, DisabledConsoleOutput
 
 from redbot.core import commands
 from redbot.core import Config
@@ -16,7 +16,6 @@ from .api import API
 from . import errors
 
 log = logging.getLogger("red.laggron.roleinvite")
-init_logger(log, "RoleInvite")
 BaseCog = getattr(commands, "Cog", object)
 _ = Translator("RoleInvite", __file__)
 

--- a/roleinvite/roleinvite.py
+++ b/roleinvite/roleinvite.py
@@ -2,25 +2,23 @@
 import asyncio
 import logging
 import discord
-import os
+
+from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
 
 from redbot.core import commands
 from redbot.core import Config
 from redbot.core import checks
-from redbot.core.data_manager import cog_data_path
 from redbot.core.i18n import cog_i18n, Translator
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.chat_formatting import pagify
 
-_ = Translator("RoleInvite", __file__)
-
 from .api import API
 from . import errors
 
-log = logging.getLogger("laggron.roleinvite")
-log.setLevel(logging.DEBUG)
-
+log = logging.getLogger("red.laggron.roleinvite")
+init_logger(log, "RoleInvite")
 BaseCog = getattr(commands, "Cog", object)
+_ = Translator("RoleInvite", __file__)
 
 # Red 3.0 backwards compatibility, thanks Sinbad
 listener = getattr(commands.Cog, "listener", None)
@@ -51,36 +49,9 @@ class RoleInvite(BaseCog):
         self.translator = _
 
         bot.loop.create_task(self.api.update_invites())
-        self._init_logger()
 
     __author__ = ["retke (El Laggron)"]
-    __version__ = "2.0.1"
-
-    def _init_logger(self):
-        log_format = logging.Formatter(
-            f"%(asctime)s %(levelname)s {self.__class__.__name__}: %(message)s",
-            datefmt="[%d/%m/%Y %H:%M]",
-        )
-        # logging to a log file
-        # file is automatically created by the module, if the parent foler exists
-        cog_path = cog_data_path(self)
-        if cog_path.exists():
-            log_path = cog_path / f"{os.path.basename(__file__)[:-3]}.log"
-            file_handler = logging.FileHandler(log_path)
-            file_handler.setLevel(logging.DEBUG)
-            file_handler.setFormatter(log_format)
-            log.addHandler(file_handler)
-
-        # stdout stuff
-        stdout_handler = logging.StreamHandler()
-        stdout_handler.setFormatter(log_format)
-        # if --debug flag is passed, we also set our debugger on debug mode
-        if logging.getLogger("red").isEnabledFor(logging.DEBUG):
-            stdout_handler.setLevel(logging.DEBUG)
-        else:
-            stdout_handler.setLevel(logging.INFO)
-        log.addHandler(stdout_handler)
-        self.stdout_handler = stdout_handler
+    __version__ = "2.0.2"
 
     async def _check(self, ctx: commands.Context):
         """
@@ -545,11 +516,11 @@ class RoleInvite(BaseCog):
         if not ctx.command.cog_name == self.__class__.__name__:
             # That error doesn't belong to the cog
             return
-        log.removeHandler(self.stdout_handler)  # remove console output since red also handle this
-        log.error(
-            f"Exception in command '{ctx.command.qualified_name}'.\n\n", exc_info=error.original
-        )
-        log.addHandler(self.stdout_handler)  # re-enable console output for warnings
+        with DisabledConsoleOutput(log):
+            log.error(
+                f"Exception in command '{ctx.command.qualified_name}'.\n\n",
+                exc_info=error.original,
+            )
 
     def __unload(self):
         # breaking change __unload -> cog_unload
@@ -560,4 +531,4 @@ class RoleInvite(BaseCog):
 
         # remove all handlers from the logger, this prevents adding
         # multiple times the same handler if the cog gets reloaded
-        log.handlers = []
+        close_logger(log)

--- a/say/__init__.py
+++ b/say/__init__.py
@@ -3,6 +3,7 @@ import importlib.util
 from .say import Say
 
 from redbot.core.errors import CogLoadError
+from laggron_utils import init_logger
 
 if not importlib.util.find_spec("laggron_utils"):
     raise CogLoadError(
@@ -16,6 +17,7 @@ log = logging.getLogger("red.laggron.say")
 
 
 async def setup(bot):
+    init_logger(log, Say.__class__.__name__)
     n = Say(bot)
     bot.add_cog(n)
     log.debug("Cog successfully loaded on the instance.")

--- a/say/__init__.py
+++ b/say/__init__.py
@@ -1,7 +1,18 @@
 import logging
+import importlib.util
 from .say import Say
 
-log = logging.getLogger("laggron.say")
+from redbot.core.errors import CogLoadError
+
+if not importlib.util.find_spec("laggron_utils"):
+    raise CogLoadError(
+        "You need the `laggron_utils` package for any cog from Laggron's Dumb Cogs. "
+        "Use the command `[p]pipinstall git+https://github.com/retke/Laggron-utils.git` "
+        "or type `pip3 install -U git+https://github.com/retke/Laggron-utils.git` in the "
+        "terminal to install the library."
+    )
+
+log = logging.getLogger("red.laggron.say")
 
 
 async def setup(bot):

--- a/say/info.json
+++ b/say/info.json
@@ -11,7 +11,9 @@
     "hidden": false,
     "install_msg": "Thank you for installing the say cog. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/say.html\n\nType `[p]help Say` for a quick overview of the commands.",
     "required_cogs": {},
-    "requirements": [],
+    "requirements": [
+        "laggron_utils"
+    ],
     "short": "Speak as the bot through multiple options.",
     "tags": [
         "rift",

--- a/say/info.json
+++ b/say/info.json
@@ -12,7 +12,7 @@
     "install_msg": "Thank you for installing the say cog. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/say.html\n\nType `[p]help Say` for a quick overview of the commands.",
     "required_cogs": {},
     "requirements": [
-        "laggron_utils"
+        "git+https://github.com/retke/laggron-utils"
     ],
     "short": "Speak as the bot through multiple options.",
     "tags": [

--- a/say/say.py
+++ b/say/say.py
@@ -5,14 +5,13 @@ import asyncio
 import logging
 
 from typing import Optional
-from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
+from laggron_utils.logging import close_logger, DisabledConsoleOutput
 
 from redbot.core import checks, commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.tunnel import Tunnel
 
 log = logging.getLogger("red.laggron.say")
-init_logger(log, "Say")
 _ = Translator("Say", __file__)
 BaseCog = getattr(commands, "Cog", object)
 

--- a/warnsystem/__init__.py
+++ b/warnsystem/__init__.py
@@ -18,9 +18,16 @@ if not importlib.util.find_spec("dateutil"):
         "Use the command `[p]pipinstall python-dateutil` or type "
         "`pip3 install python-dateutil` in the terminal to install the library."
     )
+if not importlib.util.find_spec("laggron_utils"):
+    raise CogLoadError(
+        "You need the `laggron_utils` package for any cog from Laggron's Dumb Cogs. "
+        "Use the command `[p]pipinstall git+https://github.com/retke/Laggron-utils.git` "
+        "or type `pip3 install -U git+https://github.com/retke/Laggron-utils.git` in the "
+        "terminal to install the library."
+    )
 
 _ = Translator("WarnSystem", __file__)
-log = logging.getLogger("laggron.warnsystem")
+log = logging.getLogger("red.laggron.warnsystem")
 
 
 async def _save_backup(config):

--- a/warnsystem/__init__.py
+++ b/warnsystem/__init__.py
@@ -4,6 +4,7 @@ import re
 
 from redbot.core.i18n import Translator
 from datetime import datetime, timedelta
+from laggron_utils import init_logger, close_logger
 
 from .warnsystem import WarnSystem
 
@@ -184,10 +185,11 @@ async def update_config(bot, config):
 
 
 async def setup(bot):
+    init_logger(log, WarnSystem.__class__.__name__)
     n = WarnSystem(bot)
     # the cog conflicts with the core Warnings cog, we must check that
     if "Warnings" in bot.cogs:
-        log.handlers = []  # still need some cleaning up
+        close_logger(log)  # still need some cleaning up
         raise CogLoadError(
             "You need to unload the Warnings cog to load "
             "this cog. Type `[p]unload warnings` and try again."
@@ -200,7 +202,7 @@ async def setup(bot):
             "Contact support for further instructions.",
             exc_info=e,
         )
-        log.handlers = []  # still need some cleaning up
+        close_logger(log)  # still need some cleaning up
         raise CogLoadError(
             "After an update, the cog tried to perform changes to the saved data but an error "
             "occured. Read your console output or warnsystem.log (located over "

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -21,7 +21,7 @@ except RuntimeError:
 from .cache import MemoryCache
 from . import errors
 
-log = logging.getLogger("laggron.warnsystem")
+log = logging.getLogger("red.laggron.warnsystem")
 _ = Translator("WarnSystem", __file__)
 id_pattern = re.compile(r"([0-9]{15,21})$")
 

--- a/warnsystem/cache.py
+++ b/warnsystem/cache.py
@@ -8,7 +8,7 @@ from redbot.core.bot import Red
 
 from typing import Mapping, Optional
 
-log = logging.getLogger("laggron.warnsystem")
+log = logging.getLogger("red.laggron.warnsystem")
 
 
 class MemoryCache:

--- a/warnsystem/converters.py
+++ b/warnsystem/converters.py
@@ -13,7 +13,7 @@ from redbot.core.i18n import Translator
 from .api import UnavailableMember
 
 _ = Translator("WarnSystem", __file__)
-log = logging.getLogger("laggron.warnsystem")
+log = logging.getLogger("red.laggron.warnsystem")
 
 
 # credit to mikeshardmind (Sinbad) for parse_time

--- a/warnsystem/info.json
+++ b/warnsystem/info.json
@@ -11,7 +11,10 @@
     "hidden": false,
     "install_msg": "Thank you for installing the warnsystem cog. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/warnsystem.html\n\nType `[p]help WarnSystem` for a quick overview of the commands\n**This cog conflicts with Warnings which must be unloaded.**",
     "required_cogs": {},
-    "requirements": [],
+    "requirements": [
+        "python-dateutil",
+        "git+https://github.com/retke/Laggron-utils.git"
+    ],
     "short": "Moderation tools, providing an alternative to core Red.",
     "tags": [
         "warn",

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -14,7 +14,7 @@ from redbot.core.utils.chat_formatting import pagify
 
 from .abc import MixinMeta
 
-log = logging.getLogger("laggron.warnsystem")
+log = logging.getLogger("red.laggron.warnsystem")
 _ = Translator("WarnSystem", __file__)
 
 

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -3,17 +3,16 @@ import discord
 import logging
 import asyncio
 import re
-import os
 
 from typing import Optional
 from asyncio import TimeoutError as AsyncTimeoutError
 from abc import ABC
 from datetime import datetime, timedelta
+from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
 
 from redbot.core import commands, Config, checks
 from redbot.core.commands.converter import TimedeltaConverter
 from redbot.core.i18n import Translator, cog_i18n
-from redbot.core.data_manager import cog_data_path
 from redbot.core.utils import predicates, menus, mod
 from redbot.core.utils.chat_formatting import pagify
 
@@ -24,8 +23,8 @@ from .cache import MemoryCache
 from .converters import AdvancedMemberSelect
 from .settings import SettingsMixin
 
-log = logging.getLogger("laggron.warnsystem")
-log.setLevel(logging.DEBUG)
+log = logging.getLogger("red.laggron.warnsystem")
+init_logger(log, "WarnSystem")
 _ = Translator("WarnSystem", __file__)
 BaseCog = getattr(commands, "Cog", object)
 
@@ -224,36 +223,10 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         self.cache = MemoryCache(self.bot, self.data)
         self.api = API(self.bot, self.data, self.cache)
 
-        self._init_logger()
         self.task: asyncio.Task
 
-    __version__ = "1.3.5"
+    __version__ = "1.3.6"
     __author__ = ["retke (El Laggron)"]
-
-    def _init_logger(self):
-        log_format = logging.Formatter(
-            f"%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="[%Y-%m-%d %H:%M]"
-        )
-        # logging to a log file
-        # file is automatically created by the module, if the parent foler exists
-        cog_path = cog_data_path(self)
-        if cog_path.exists():
-            log_path = cog_path / f"{os.path.basename(__file__)[:-3]}.log"
-            file_handler = logging.FileHandler(log_path)
-            file_handler.setLevel(logging.DEBUG)
-            file_handler.setFormatter(log_format)
-            log.addHandler(file_handler)
-
-        # stdout stuff
-        stdout_handler = logging.StreamHandler()
-        stdout_handler.setFormatter(log_format)
-        # if --debug flag is passed, we also set our debugger on debug mode
-        if logging.getLogger("red").isEnabledFor(logging.DEBUG):
-            stdout_handler.setLevel(logging.DEBUG)
-        else:
-            stdout_handler.setLevel(logging.INFO)
-        log.addHandler(stdout_handler)
-        self.stdout_handler = stdout_handler
 
     # helpers
     async def call_warn(self, ctx, level, member, reason=None, time=None):
@@ -1470,11 +1443,11 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
                 )
             )
             return
-        log.removeHandler(self.stdout_handler)  # remove console output since red also handle this
-        log.error(
-            f"Exception in command '{ctx.command.qualified_name}'.\n\n", exc_info=error.original
-        )
-        log.addHandler(self.stdout_handler)  # re-enable console output for warnings
+        with DisabledConsoleOutput(log):
+            log.error(
+                f"Exception in command '{ctx.command.qualified_name}'.\n\n",
+                exc_info=error.original,
+            )
 
     # correctly unload the cog
     def __unload(self):
@@ -1485,7 +1458,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
 
         # remove all handlers from the logger, this prevents adding
         # multiple times the same handler if the cog gets reloaded
-        log.handlers = []
+        close_logger(log)
 
         # stop checking for unmute and unban
         self.task.cancel()

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -8,7 +8,7 @@ from typing import Optional
 from asyncio import TimeoutError as AsyncTimeoutError
 from abc import ABC
 from datetime import datetime, timedelta
-from laggron_utils.logging import init_logger, close_logger, DisabledConsoleOutput
+from laggron_utils.logging import close_logger, DisabledConsoleOutput
 
 from redbot.core import commands, Config, checks
 from redbot.core.commands.converter import TimedeltaConverter
@@ -24,7 +24,6 @@ from .converters import AdvancedMemberSelect
 from .settings import SettingsMixin
 
 log = logging.getLogger("red.laggron.warnsystem")
-init_logger(log, "WarnSystem")
 _ = Translator("WarnSystem", __file__)
 BaseCog = getattr(commands, "Cog", object)
 


### PR DESCRIPTION
## Pull request type

- [x] Feature addition
- [ ] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes

I recently made a new python package (not uploaded on Pypi) named `laggron_utils` ([Github repo](https://github.com/retke/laggron-utils)) that will contain tools utils shared across all of my cogs.

For now, I'm just moving all of my logging functions there, since it was just some copy pasted code. It is now easier to maintain it, push the changes to all repos in one go, and make in the future more complex tools (maybe the comeback of Sentry).

This also resolves #75.