### PR TITLE
[WarnSystem] Reduce the iterations needed to get an invite channel

### DIFF
--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -1085,19 +1085,15 @@ class API:
 
     async def _check_endwarn(self):
         async def reinvite(guild, user, reason, duration):
-            channel = None
-            # find an ideal channel for the invite
-            # we get the one with the most members in the order of the guild
-            try:
-                channel = sorted(
-                    [
-                        x
-                        for x in guild.text_channels
-                        if x.permissions_for(guild.me).create_instant_invite
-                    ],
-                    key=lambda x: (x.position, len(x.members)),
-                )[0]
-            except IndexError:
+            channel = next(
+                (
+                    c  # guild.text_channels is already sorted by position
+                    for c in guild.text_channels
+                    if c.permissions_for(guild.me).create_instant_invite
+                ),
+                None,
+            )
+            if channel is None:
                 # can't find a valid channel
                 log.info(
                     f"[Guild {guild.id}] Can't find a text channel where I can create an invite "


### PR DESCRIPTION
## Pull request type

- [ ] Feature addition
- [ ] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes

Saw something in your support channel, went to take a look in context

      - guild.text_channels is already sorted by position
      - prior key was (channel.position, len(channel.members))
      - channel.members is a list comp calculated on demand
      - channel.members portion of the key would never be used before

      With these, I dropped the sorted use, from that I made it lazy
      using a generator expression + next()