### PR TITLE
[instantcmd] Fix source for long commands

### DIFF
--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -365,7 +365,9 @@ cog at this point.
             await ctx.send("Command not found.")
             return
         await ctx.send(f"Source code for `{ctx.clean_prefix}{command}`:")
-        await ctx.send_interactive(pagify(_commands[command], shorten_by=10), box_lang="py", timeout=60)
+        await ctx.send_interactive(
+            pagify(_commands[command], shorten_by=10), box_lang="py", timeout=60
+        )
 
     @commands.command(hidden=True)
     @checks.is_owner()

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -364,11 +364,8 @@ cog at this point.
         if command not in _commands:
             await ctx.send("Command not found.")
             return
-        message = (
-            f"Source code for `{ctx.prefix}{command}`:\n" + "```Py\n" + _commands[command] + "```"
-        )
-        for page in pagify(message):
-            await ctx.send(page)
+        await ctx.send(f"Source code for `{ctx.clean_prefix}{command}`:")
+        await ctx.send_interactive(pagify(_commands[command], shorten_by=10), box_lang="py", timeout=60)
 
     @commands.command(hidden=True)
     @checks.is_owner()

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -80,7 +80,7 @@ class InstantCommands(BaseCog):
         bot.loop.create_task(self.resume_commands())
 
     __author__ = ["retke (El Laggron)"]
-    __version__ = "1.2.1"
+    __version__ = "1.2.2"
 
     # def get_config_identifier(self, name):
     # """


### PR DESCRIPTION
<!--
Hello and thanks for contributing to Laggron's Dumb Cogs
Before submitting your PR, please fill out the following questions
To tick a case, place an x between the brackets.
-->

## Pull request type

- [ ] Feature addition
- [X] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes
`[p]instantcmd source` wraps the entire message in a multiline code block before pagifying, which breaks formatting for long commands. [(Example screenshot)](https://cdn.discordapp.com/attachments/492050319241379871/750814990222491748/unknown.png)
This wraps each page in a multiline code block, as well as uses `ctx.send_interactive` to avoid spamming the channel.