### PR TITLE
use guild owner_id

### DIFF
--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -923,13 +923,13 @@ class API:
                     ).format(bot_role=guild.me.top_role.name, member_role=member.top_role.name)
                 )
             if await self.data.guild(guild).respect_hierarchy() and (
-                not (await self.bot.is_owner(author) or author == guild.owner)
+                not (await self.bot.is_owner(author) or author.id == guild.owner_id)
                 and member.top_role.position >= author.top_role.position
             ):
                 return errors.NotAllowedByHierarchy(
                     "The moderator is lower than the member in the servers's role hierarchy."
                 )
-            if level > 2 and member == guild.owner:
+            if level > 2 and member.id == guild.owner_id:
                 return errors.MissingPermissions(
                     _("I can't take actions on the owner of the guild.")
                 )
@@ -1271,7 +1271,7 @@ class API:
             return
         if member.bot:
             return
-        if guild.owner.id == member.id:
+        if guild.owner_id == member.id:
             return
         if not self.cache.is_automod_enabled(guild):
             return

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -224,7 +224,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
 
         self.task: asyncio.Task
 
-    __version__ = "1.3.11"
+    __version__ = "1.3.12"
     __author__ = ["retke (El Laggron)"]
 
     # helpers


### PR DESCRIPTION
<!--
Hello and thanks for contributing to Laggron's Dumb Cogs
Before submitting your PR, please fill out the following questions
To tick a case, place an x between the brackets.
-->

## Pull request type

- [ ] Feature addition
- [x] Bug fix
- [ ] Grammar or minor corrections

## Description of the changes
Uses the cached guild owner_id attribute rather than owner object as unchunked guilds may not have an owner object. [Relevant screenshot](https://i.imgur.com/lxvu2EX.png)
