### PR TITLE
[instacmd] Refactor resume_commands

### DIFF
--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -72,7 +72,7 @@ class InstantCommands(BaseCog):
         bot.loop.create_task(self.resume_commands())
 
     __author__ = ["retke (El Laggron)"]
-    __version__ = "1.3.1"
+    __version__ = "1.3.2"
 
     # def get_config_identifier(self, name):
     # """

--- a/instantcmd/instantcmd.py
+++ b/instantcmd/instantcmd.py
@@ -131,18 +131,24 @@ class InstantCommands(BaseCog):
         Load all instant commands made.
         This is executed on load with __init__
         """
+        dev_values = await self.data.dev_values()
+        for name, code in dev_values.items():
+            try:
+                function = self.get_function_from_str(code, name)
+            except Exception as e:
+                log.exception("An exception occurred while trying to resume dev value %s", name)
+            else:
+                self.bot.add_dev_env_value(name, function)
+                log.debug(f"Added dev value %s", name)
 
         _commands = await self.data.commands()
         for name, command_string in _commands.items():
-            function = self.get_function_from_str(command_string, name)
-            self.load_command_or_listener(function)
-        if self.bot.get_cog("Dev") is None:
-            return
-        dev_values = await self.data.dev_values()
-        for name, code in dev_values.items():
-            function = self.get_function_from_str(code, name)
-            self.bot.add_dev_env_value(name, function)
-            log.debug(f"Added dev value {name}")
+            try:
+                function = self.get_function_from_str(command_string, name)
+            except Exception as e:
+                log.exception("An exception occurred while trying to resume command %s", name)
+            else:
+                self.load_command_or_listener(function)
 
     async def remove_commands(self):
         async with self.data.commands() as _commands:


### PR DESCRIPTION
## Pull request type

Bug fix

## Description of the changes

Makes the following changes to `resume_commands`:
1) Don't require the dev cog to load dev values
    - Due to another 3rd party cog (Trusty's loaddev), the presence of the dev cog can change during runtime. Since dev env values are an attribute of the bot itself and don't inherently require the dev cog to set them, may as well set them anyway.
2) Catch and log errors, then continue resuming rather than raise an unhandled exception and stopping.
    - Resuming commands can break if one command that didn't raise an error before raises an error now (e.g. if a required pip library has been uninstalled since adding the command).