### PR TITLE
[WarnSystem] Use fetch_ban endpoint

### DIFF
--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1300,7 +1300,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         """
         guild = ctx.guild
         try:
-            ban_entry = await guild.fetch_ban(member_id)
+            ban_entry = await guild.fetch_ban(discord.Object(member_id))
         except discord.NotFound:
             await ctx.send(_("That user is not banned."))
             return

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1290,18 +1290,21 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
             await ctx.send(page)
 
     @commands.command()
+    @commands.bot_has_permissions(ban_members=True)
     @checks.mod_or_permissions(ban_members=True)
-    async def wsunban(self, ctx: commands.Context, member: UnavailableMember):
+    async def wsunban(self, ctx: commands.Context, member_id: int):
         """
         Unban a member banned with WarnSystem.
 
         *wsunban = WarnSystem unban. Feel free to add an alias.*
         """
         guild = ctx.guild
-        bans = await guild.bans()
-        if member.id not in [x.user.id for x in bans]:
+        try:
+            ban_entry = await guild.fetch_ban(member_id)
+        except discord.NotFound:
             await ctx.send(_("That user is not banned."))
             return
+        member = ban_entry.user
         try:
             await guild.unban(member)
         except discord.errors.HTTPException as e:


### PR DESCRIPTION
## Pull request type

Bug fix

## Description of the changes
Fixes a bug caused by [a breaking Discord API change](https://discord.com/developers/docs/change-log#guild-bans-pagination), which caused only the oldest 1000 bans to be checked.

Note that this breaks typechecking due to the fact that banned users are User objects, but the various cache temp_action methods are typehinted for `Optional[discord.Member]`. All such temp_action methods seem to only require `Optional[discord.abc.Snowflake]` in actuality. This PR doesn't touch these typehints, but I would be willing to modify those as well if you want.

Since fetching bans also gives you a resolved User object, I also changed the typehint to just `int` since faking such an object would no longer be necessary.

I don't personally use WarnSystem so I haven't tested these changes.
