### PR TITLE
Use gender neutral language to refer to users whenever possible

### DIFF
--- a/docs/instantcommands.rst
+++ b/docs/instantcommands.rst
@@ -40,7 +40,7 @@ from Discord. You just need basic Python and discord.py knowledge.
 
 You can also edit the Dev's environment added with Red 3.4.6.
 
-Here's an example of his it works:
+Here's an example of how it works:
 
 .. image:: .ressources/EXAMPLES/InstantCommands-example.png
 

--- a/docs/roleinvite.rst
+++ b/docs/roleinvite.rst
@@ -42,7 +42,7 @@ link is linked to one or more roles. This mean that,
 every time a new user join the server, if they used the invite A to
 join the server, they will get the list of roles linked to the invite A.
 
-You can link many roles  to multiple invites, so you can imagine something
+You can link many roles to multiple invites, so you can imagine something
 like "click **here** if you are an engineer, else click **here** if you're
 an architect", and make roleinvite give the engineer or architect roles.
 
@@ -235,7 +235,7 @@ This can happens if the role hierarchy is modified after the roles got linked.
 Remember that a bot/member can only add roles that are below them in the role
 hierarchy. 
 
-Modify the role hirearchy and make sure all necessary roles are **below**
+Modify the role hierarchy and make sure all necessary roles are **below**
 the bot's highest role. If it still doesn't work, try to link the role again.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/roleinvite.rst
+++ b/docs/roleinvite.rst
@@ -39,8 +39,8 @@ Before giving the commands list, I'd like to show you how the cog is working.
 
 The cog works with what I call invite links. Each invite
 link is linked to one or more roles. This mean that,
-every time a new user join the server, if he used the invite A to
-join the server, he will get the list of roles linked to the invite A.
+every time a new user join the server, if they used the invite A to
+join the server, they will get the list of roles linked to the invite A.
 
 You can link many roles  to multiple invites, so you can imagine something
 like "click **here** if you are an engineer, else click **here** if you're
@@ -48,10 +48,10 @@ an architect", and make roleinvite give the engineer or architect roles.
 
 You can also link roles to default or main autorole.
 If you link roles to the main autorole,
-the new member will get these roles if he
+the new member will get these roles if they
 joined with an unlinked invite. If you link roles
 to the default autorole, new users will always get
-these roles, whatever invite he used.
+these roles, whatever invite they used.
 
 Here's a schema for a better understanding:
 
@@ -232,7 +232,7 @@ Some roles are not added to the new members
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This can happens if the role hierarchy is modified after the roles got linked.
-Remember that a bot/member can only add roles that are below him in the role
+Remember that a bot/member can only add roles that are below them in the role
 hierarchy. 
 
 Modify the role hirearchy and make sure all necessary roles are **below**

--- a/docs/roleinvite.rst
+++ b/docs/roleinvite.rst
@@ -221,7 +221,7 @@ This may be available in a future release.
 The bot suddenly stopped adding roles to the new members
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The bot will automatically turn off the autorole system if he lose the ``Manage
+The bot will automatically turn off the autorole system if it loses the ``Manage
 sever`` or the ``Add roles`` permissions, which are absolutely necessary for the cog.
 
 If you added the permissions back, enable the autorole again with the command 

--- a/docs/tournaments.rst
+++ b/docs/tournaments.rst
@@ -99,7 +99,7 @@ Add to all of this tools for streamers too!
 *   The streamer has access to the channels, so that they can also communicate
     with the players.
 
-This was tested with tournaments up to 256 players, and I can personnaly
+This was tested with tournaments up to 256 players, and I can personally
 confirm this makes the organizers' job way easier.
 
 ^^^^^^^^^^^^^^^^^^

--- a/docs/tournaments.rst
+++ b/docs/tournaments.rst
@@ -56,7 +56,7 @@ manage everything:
     the stage list, banning stages/characters...
 
 *   The bot checks activity in the channels. If one player doesn't talk within
-    the first minutes, he will be disqualified.
+    the first minutes, they will be disqualified.
 
 *   Once the players have done their match, they can set their score with a
     command.
@@ -96,7 +96,7 @@ Add to all of this tools for streamers too!
 *   If a match is launched but attached to a streamer, it will be paused until
     it is their turn. They will then receive the informations set above.
 
-*   The streamer has access to the channels, so that he can also communicate
+*   The streamer has access to the channels, so that they can also communicate
     with the players.
 
 This was tested with tournaments up to 256 players, and I can personnaly
@@ -171,8 +171,8 @@ Next step, the roles with ``[p]tset roles``:
 Some additional settings you can set:
 
 *   ``[p]tset delay`` defines when a player is considered AFK and must be
-    disqualified. This only listens for his first message in his channel, once
-    someone spoke, he's safe. Defaults to 10 minutes.
+    disqualified. This only listens for their first message in their channel, once
+    someone spoke, they're safe. Defaults to 10 minutes.
 
 *   ``[p]tset start_bo5`` defines at what point you want to move from BO3
     format to BO5.
@@ -362,8 +362,8 @@ categories.
 
 ----
 
-First thing to note: if a player does not talk in his channel within the 10
-first minutes after the channel creation, he will be disqualified (you can
+First thing to note: if a player does not talk in their channel within the 10
+first minutes after the channel creation, they will be disqualified (you can
 customize or disable this delay with ``[p]tset delay``). You are warned of this
 in the T.O. channel.
 
@@ -383,7 +383,7 @@ being terminated (score set), relaunched (score reset) or even cancelled
 (score reset with child matches ongoing). This will also be announced in the
 T.O. channel.
 
-The winner of a match will set his score with the ``[p]win`` command, inside
+The winner of a match will set their score with the ``[p]win`` command, inside
 the scores channel if set.
 
 Players can use at any time ``[p]ff`` for forfeiting a match (they can still
@@ -571,7 +571,7 @@ task. This is a task launched when you start your tournament that runs every
 *   Launch pending matches
 
 *   Check for AFK players (someone didn't talk within the first 10 minutes in
-    his channel, configurable with ``[p]tset delay``), and delete inactive
+    their channel, configurable with ``[p]tset delay``), and delete inactive
     channels (score reported and no message sent for 5 minutes)
 
 *   Call streams

--- a/docs/warnsystem.rst
+++ b/docs/warnsystem.rst
@@ -69,7 +69,7 @@ the rewrite of the BetterMod cog for Red V3. Here is a quick start guide.
     1.  Simple warning
     2.  Server mute (can be temporary)
     3.  Kick
-    4.  Softban (ban then quickly unban the member, to clean his messages)
+    4.  Softban (ban then quickly unban the member, to clean their messages)
     5.  Ban (can be temporary, and also ban members not on the server)
 
     Each warn will send a DM to the warned member, a log in the modlog channel,
@@ -90,7 +90,7 @@ for your bot:
 
 *   **Role removal:** Discord permissions can be a pain in the ass, and mute
     with role can be a problem. The most common situation is where a member
-    has a role that grants him write access in a channel and the mute role
+    has a role that grants them write access in a channel and the mute role
     cannot overwrite that. This is why this option exists, enable it with
     ``[p]warnset removeroles`` and all roles will be removed and reassigned
     once the mute ends or if the warning is deleted.
@@ -106,7 +106,7 @@ for your bot:
 
 *   **Hierarchy:** To make sure your moderators doesn't abuse with their
     permissions, you can enable hierarchy protection. This means that the bot
-    will block a moderator trying to warn a member higher than him in the role
+    will block a moderator trying to warn a member higher than them in the role
     hierarchy, like with the manual Discord actions.
 
 *   **Multiple modlogs:** If you want to send all warnings, mutes, kicks and
@@ -236,8 +236,8 @@ Mutes the member with a role on the server.
     command to create/assign the role.
 
 The member will get the mute role for the specified time. You can edit this
-role as you like to allow him some channels for example. Removing his role
-manually will cancel his mute without problem, but the warn will still exist.
+role as you like to allow them some channels for example. Removing their role
+manually will cancel the mute without problems, but the warn will still exist.
 Removing the warn with the ``[p]warnings`` command will also remove the role
 if needed.
 
@@ -320,7 +320,7 @@ warn 4
 
 **Description**
 
-Bans the member from the server, then unbans him, to mass delete his messages.
+Bans the member from the server, then unbans them, to mass delete their messages.
 This can be considered as a kick with a massive cleanup of messages.
 
 The bot will delete 7 days of messages by default, this can be changed with the
@@ -797,7 +797,7 @@ Configures the automod based on member's modlog. This allows automatic actions
 based on previous given warnings.
 
 For example, you can make it so if someone receives 3 level 1 warnings within a
-week, he will automatically get a level 3 (kick) warning with the reason you
+week, they will automatically get a level 3 (kick) warning with the reason you
 defined. A lot of options are possible.
 
 Use ``[p]automod warn add`` to add a new rule. This will open an interactive
@@ -1295,10 +1295,10 @@ warnset removeroles
 
 **Description**
 
-Defines if the bot should remove all roles from a member when he gets muted
+Defines if the bot should remove all roles from a member when they get muted
 (warn 2). This can be useful because, in some cases, some channels can still
-be accessible to a muted member (for example, when he has a role that grants
-him access in a private channel).
+be accessible to a muted member (for example, when they have a role that grants
+them access to a private channel).
 
 This behaviour is due to Discord's permissions system ; the mute role is denied
 from sending messages and adding reactions in all text channels, but if another

--- a/docs/warnsystem.rst
+++ b/docs/warnsystem.rst
@@ -1212,7 +1212,7 @@ warnset mute
 **Description**
 
 Creates a role used for muting the members, or set an existing one as the mute
-role. If you don't provide any role, the bot will create one below his top
+role. If you don't provide any role, the bot will create one below its top
 role, then deny the "Send messages" and "Add reactions" on all text channels.
 **Editing all channels takes a long time, depending on the number of text
 channels you have on the server,** so don't worry if nothing happens for about

--- a/roleinvite/README.md
+++ b/roleinvite/README.md
@@ -2,7 +2,7 @@
 
 This is the RoleInvite cog for Red. This is a quite different autorole cog, which works depending on the invite the member used to join!
 
-You can set the autorole system so when a member joins with the invite x, he gets the role y. You can also set it so when someone joins with an unlinked invite, he gets another role. There's even a setting to always give a role to new members regardless of the invite used.
+You can set the autorole system so when a member joins with the invite x, they get the role y. You can also set it so when someone joins with an unlinked invite, they get another role. There's even a setting to always give a role to new members regardless of the invite used.
 
 There is a detailed documentation, covering all commands in details, please read this if you want to know how commands works in details: https://laggron.red/roleinvite.html
 

--- a/roleinvite/info.json
+++ b/roleinvite/info.json
@@ -7,7 +7,7 @@
         0,
         0
     ],
-    "description": "Autorole based on the invite the user used.\nIf the user joined using invite x, he will get a list of roles linked to invite x.",
+    "description": "Autorole based on the invite the user used.\nIf the user joined using invite x, they will get a list of roles linked to invite x.",
     "hidden": false,
     "install_msg": "Thanks for installing roleinvite. Please check the wiki for all informations about the cog.\nhttps://laggrons-dumb-cogs.readthedocs.io/roleinvite.html\nEverything you need to know about setting up the cog is here.\nFor a quick guide, type `[p]help RoleInvite`, just keep in mind that the bot needs the `Manage server` and the `Add roles` permissions.",
     "required_cogs": {},

--- a/roleinvite/roleinvite.py
+++ b/roleinvite/roleinvite.py
@@ -190,7 +190,7 @@ class RoleInvite(BaseCog):
             await ctx.send(
                 _(
                     "The role `{}` is now linked to the default autorole system. "
-                    "(new members will always get this role, whatever invite he used.)"
+                    "(new members will always get this role, whatever invite they used.)"
                 ).format(role.name)
             )
             return

--- a/say/README.md
+++ b/say/README.md
@@ -1,6 +1,6 @@
 # Say
 
-This is the Say cog for Red, which allows you to make your bot send text or event upload images. It can also be used as a bridge in DM so you can see what the bot sees, and give him messages to send.
+This is the Say cog for Red, which allows you to make your bot send text or event upload images. It can also be used as a bridge in DM so you can see what the bot sees, and give it messages to send.
 
 There is a detailed documentation, covering all commands in details, please read this if you want to know how commands works in details: https://laggron.red/say.html
 

--- a/tournaments/README.md
+++ b/tournaments/README.md
@@ -9,7 +9,7 @@ The cog supports the registration and check-in of the tournament, including seed
 Then, once the game starts, just sit down and watch ~~the magic~~ the bot manage everything:
 - For each match, a channel will be created with the two players of this match.
 - They have their own place for discussing about the tournament, checking the stage list, banning stages/characters...
-- The bot checks activity in the channels. If one player doesn't talk within the first minutes, he will be disqualified.
+- The bot checks activity in the channels. If one player doesn't talk within the first minutes, they will be disqualified.
 - Once the players have done their match, they can set their score with a command.
 - Players can also forfeit a match, or disqualify themselves.
 - As the tournament goes on, outdated channels will be deleted, and new ones will be created for the upcoming matches, the bot is constantly checking the bracket.
@@ -24,7 +24,7 @@ Add to all of this tools for streamers too!
 - Streamers can add themselves to the tournament (not as a player) and comment some matches
 - They will choose the matches they want to cast, and also provide informations to players (for example, the room code and ID for smash bros)
 - If a match is launched but attached to a streamer, it will be paused until it is their turn. They will then receive the informations set above.
-- The streamer has access to the channels, so that he can also communicate with the players.
+- The streamer has access to the channels, so that they can also communicate with the players.
 
 This was tested with tournaments up to 256 players, and I can personnaly confirm this makes the organizers' job way easier.
 
@@ -115,9 +115,9 @@ Now the interesting part, the `objects` folder:
 - `__init__.py` Nothing lol
 - `base.py` The core of your tournaments. There are 4 classes :
   - `Tournament` The first object created, it contains all the config you set, plus infos from the API. Then there are a lot of various methods, like the loop task ran during a tournament, code for launching the sets, sending messages, checking for timeout, adding a player... Then there are abstract methods, they represent API calls but just do nothing at this point, but we'll define them in the next file. There are also 3 lists for each of the objects described below. If you want to delete an object, remove it from those lists.
-  - `Participant` Represents a participant in the tournament. It inherits from `discord.Member` and adds some attributes and methods useful for our tournament, such as its player ID on the bracket, his current match, and see if he spoke (AFK check). There are once again abstract methods representing API calls, like DQing.
+  - `Participant` Represents a participant in the tournament. It inherits from `discord.Member` and adds some attributes and methods useful for our tournament, such as its player ID on the bracket, their current match, and see if they spoke (AFK check). There are once again abstract methods representing API calls, like DQing.
   - `Match` Represents a match. It is associated to two participants, and contains the stuff for a match (setting scores, announcing changes, checking for DQ)... It is usually associated with a `discord.TextChannel` (if creating the channel failed, we move the stuff in DM). Still more abstract methods for API calls.
-  - `Streamer` Very small object that represents a streamer, and doesn't have API calls (we keep that for ourselves for now). It contains a list of the sets he will comment, and additional info.
+  - `Streamer` Very small object that represents a streamer, and doesn't have API calls (we keep that for ourselves for now). It contains a list of the sets they will comment, and additional info.
 - `challonge.py` This file has 3 classes: `ChallongeTournament`, `ChallongeParticipant` and `ChallongeMatch`. You guessed it, they all inherit from the objects in `base.py` and will define those abstract methods with the actual API calls to Challonge. Stuff in here is specific to Challonge, it treats raw data from the Challonge API and adapts it to the structure of the base objects.
 
 You may have guessed it, using this structure, with base classes that are inherited, allows an easy integration for more services. If you have another great website for tournaments and brackets, create a new file, adapt the API data to the classes, and then there will be very few code to change, everything will work as intended!

--- a/tournaments/README.md
+++ b/tournaments/README.md
@@ -26,7 +26,7 @@ Add to all of this tools for streamers too!
 - If a match is launched but attached to a streamer, it will be paused until it is their turn. They will then receive the informations set above.
 - The streamer has access to the channels, so that they can also communicate with the players.
 
-This was tested with tournaments up to 256 players, and I can personnaly confirm this makes the organizers' job way easier.
+This was tested with tournaments up to 256 players, and I can personally confirm this makes the organizers' job way easier.
 
 There is a detailed documentation, covering all commands in details, please read this if you want to know how commands works in details: https://laggron.red/tournaments.html
 

--- a/tournaments/objects/base.py
+++ b/tournaments/objects/base.py
@@ -65,7 +65,7 @@ class Participant(discord.Member):
     match: Optional[Match]
         The player's current match. `None` if not in game.
     spoke: bool
-        Defines if the member spoke once in his channel (used for AFK check)
+        Defines if the member spoke once in their channel (used for AFK check)
     """
 
     def __init__(self, member: discord.Member, tournament: Tournament):
@@ -86,7 +86,7 @@ class Participant(discord.Member):
         self.elo = None  # ranking and seeding stuff
         self.checked_in = False
         self.match: Optional[Match] = None
-        self.spoke = False  # True as soon as the participant sent a message in his channel
+        self.spoke = False  # True as soon as the participant sent a message in their channel
         # used to detect inactivity after the launch of a set
 
     def __repr__(self):
@@ -384,7 +384,7 @@ class Match:
             try:
                 await player.send(message)
             except discord.HTTPException as e:
-                log.warning(f"Can't send a DM to {str(player)} for his set.", exc_info=e)
+                log.warning(f"Can't send a DM to {str(player)} for their set.", exc_info=e)
 
     async def send_message(self, reset: bool = False) -> bool:
         """
@@ -970,8 +970,8 @@ class Match:
         """
         Called when a player in the set forfeits this match.
 
-        This doesn't always mean that the player quits the tournament, he may continue in the
-        loser bracker.
+        This doesn't always mean that the player quits the tournament, as they may continue in the
+        loser bracket.
 
         Sets a score of -1 0
 
@@ -2313,9 +2313,9 @@ class Tournament:
         Parameters
         ----------
         member: discord.Member
-            The member to register. He must be in the server.
+            The member to register. They must be in the server.
         send_dm: bool
-            If the bot should DM the new participant for his registrations. Defaults to `True`.
+            If the bot should DM the new participant for their registrations. Defaults to `True`.
         """
         if self.limit and len(self.participants) >= self.limit:
             raise RuntimeError("Limit reached.")
@@ -2328,8 +2328,8 @@ class Tournament:
             self.participants and self.participants[-1].player_id is not None
         ):
             # either there's no ranking, in which case we always upload on register, or
-            # last registered participant has a player ID, so we should upload him to the bracket
-            # first we seed him, if possible
+            # last registered participant has a player ID, so we should upload them to the bracket
+            # first we seed them, if possible
             try:
                 await self.seed_participants()
             except Exception:
@@ -2358,7 +2358,7 @@ class Tournament:
         """
         Remove a participant.
 
-        If the player is uploaded on the bracket, he will also be removed from there. If the
+        If the player is uploaded on the bracket, they will also be removed from there. If the
         tournament has started, member will be disqualified instead.
 
         This removes roles and DMs the participant.
@@ -2564,7 +2564,7 @@ class Tournament:
                 ":information_source: Management of the scores for the "
                 "tournament **{tournament}** is automated:\n"
                 ":white_small_square: Only **the winner of the set** "
-                "sends his score with the `{prefix}win` command.\n"
+                "sends their score with the `{prefix}win` command.\n"
                 ":white_small_square: You must follow this "
                 "format: `{prefix}win 2-0, 3-2, 3-1, ...`.\n"
                 ":white_small_square: Look at the bracket to **check** the informations: {url}\n"
@@ -2967,7 +2967,7 @@ class Tournament:
         *   New player added (pre game)
 
         .. warning:: A name change on remote is considered as a player removal + addition. If the
-            name doesn't match any member, he will be rejected.
+            name doesn't match any member, they will be rejected.
         """
         raise NotImplementedError
 

--- a/tournaments/settings.py
+++ b/tournaments/settings.py
@@ -964,8 +964,8 @@ moderators and admins.
         else:
             await ctx.send(
                 _(
-                    "Done. If a player doesn't respond in his channel {delay} "
-                    "after its creation, he will automatically be disqualified."
+                    "Done. If a player doesn't respond in their channel {delay} "
+                    "after its creation, they will automatically be disqualified."
                 ).format(delay=humanize_timedelta(timedelta=delay))
             )
 
@@ -1461,7 +1461,7 @@ the start of the tournament, then closing 15 minutes before.
             if len(failed) == 1:
                 text = _(
                     ':warning: Challonge player with name "{name}" can\'t be found on '
-                    "the server. If you continue the setup, he will be disqualified."
+                    "the server. If you continue the setup, they will be disqualified."
                 ).format(name=failed[0])
             else:
                 text = _(

--- a/warnsystem/README.md
+++ b/warnsystem/README.md
@@ -7,7 +7,7 @@ This is the WarnSystem cog for Red, rewrite of the V2 cog, BetterMod. It is an a
 4. softban (ban then unban, which can cleanup the messages of an user up to a week)
 5. ban (can be a temporary ban, or even a hack ban, which allows you to ban on an user not on the server)
 
-When you warn a member, **he receives a DM** with the reason of his warn. It's also logged on your defined modlog. You can keep track of a members' warnings with an interactive menu, and even edit or delete his old warnings.
+When you warn a member, **they receive a DM** with the reason of their warn. It's also logged on your defined modlog. You can keep track of a member's warnings with an interactive menu, and even edit or delete their old warnings.
 
 There is a detailed documentation, covering all commands in details, please read this if you want to know how commands works in details: https://laggron.red/warnsystem.html
 

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -930,10 +930,10 @@ class API:
             can be lost permissions for sending messages to the modlog channel or
             interacting with the mute role.
         ~warnsystem.errors.MemberTooHigh
-            The bot is trying to take actions on someone but his top role is higher
+            The bot is trying to take actions on someone but their top role is higher
             than the bot's top role in the guild's hierarchy.
         ~warnsystem.errors.NotAllowedByHierarchy
-            The moderator trying to warn someone is lower than him in the role hierarchy,
+            The moderator trying to warn someone is lower than them in the role hierarchy,
             while the bot still has permissions to act. This is raised only if the
             hierarchy check is enabled.
         ~warnsystem.errors.MissingPermissions
@@ -1478,7 +1478,7 @@ class API:
             self.antispam[guild.id][channel.id][member.id] = data
             return
         # at this point, user is considered to be spamming
-        # we cleanup his x last messages (max_messages + 1), then either send a text warn
+        # we cleanup their x last messages (max_messages + 1), then either send a text warn
         # or perform an actual warnsystem warn (I'm confusing ik)
         if (
             data.warned is False

--- a/warnsystem/automod.py
+++ b/warnsystem/automod.py
@@ -280,7 +280,7 @@ class AutomodMixin(MixinMeta):
                 Trigger actions when a member get x warnings within the specified time.
 
         For example, if a member gets 3 warnings within a day, you can make the bot automatically \
-set him a level 3 warning with the given reason.
+set them a level 3 warning with the given reason.
         It is also possible to only include warnings given by the bot when counting.
         """
         pass
@@ -599,7 +599,7 @@ before triggering the antispam.
         await self.cache.update_automod_antispam(guild)
         await ctx.send(
             _(
-                "Done. A member will be considered as spamming if he sends "
+                "Done. A member will be considered as spamming if they sends "
                 "more than {max_messages} within {delay} seconds."
             ).format(max_messages=max_messages, delay=delay)
         )
@@ -610,12 +610,12 @@ before triggering the antispam.
         If antispam is triggered twice within this delay, perform the warn.
 
         Delay in seconds.
-        If the antispam is triggered once, a simple warning is send in the chat, mentionning the\
+        If the antispam is triggered once, a simple warning is send in the chat, mentioning the\
 member. If the same member triggers the antispam system a second time within this delay, there\
 will be an actual warning taken, the one you define with `[p]automod antispam warn`.
 
-        This is a way to tell the member he is close to being sanctioned. Of course you can\
-disable this and immediatly take actions by setting a delay of 0. Default is 60 seconds.
+        This is a way to tell the member they are close to being sanctioned. Of course you can\
+disable this and immediately take actions by setting a delay of 0. Default is 60 seconds.
         """
         guild = ctx.guild
         await self.data.guild(guild).automod.antispam.delay_before_action.set(delay)
@@ -665,7 +665,7 @@ automod infractions, like a mute after 3 warns.
         await self.cache.update_automod_antispam(guild)
         await ctx.send(
             _(
-                "If the antispam is triggered by a member, he will now receive a level "
+                "If the antispam is triggered by a member, they will now receive a level "
                 "{level} warn {duration}for the following reason:\n{reason}"
             ).format(
                 level=level,

--- a/warnsystem/errors.py
+++ b/warnsystem/errors.py
@@ -124,7 +124,7 @@ class NotAllowedByHierarchy(Exception):
 
 class LostPermissions(Exception):
     """
-    The bot lost a permission he had.
+    The bot lost a permission it had.
 
     This can be the permission to send messages in the modlog channel or use\
     the mute role.

--- a/warnsystem/errors.py
+++ b/warnsystem/errors.py
@@ -111,7 +111,7 @@ class MemberTooHigh(Exception):
 class NotAllowedByHierarchy(Exception):
     """
     The bot is set to respect the role hierarchy; the moderator requested a warn against
-    someone equal or higher than him in the hierarchy, which is not allowed by Discord
+    someone equal or higher than them in the hierarchy, which is not allowed by Discord
     permissions rules.
 
     The moderator **must** have a role higher than the warned member to continue.

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -668,9 +668,9 @@ channels, and prevented from talking in all voice channels.
         """
         Defines if the bot should remove all roles on mute
 
-        If enabled, when you set a level 2 warning on a member, he will be assigned the mute role\
-        as usual, but all of his other roles will also be removed.
-        Once the mute ends, the member will get his roles back.
+        If enabled, when you set a level 2 warning on a member, they will be assigned the mute role\
+        as usual, but all of their other roles will also be removed.
+        Once the mute ends, the member will get their roles back.
         This can be useful for role permissions issues.
         """
         guild = ctx.guild

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1336,8 +1336,8 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
 
     @listener()
     async def on_member_unban(self, guild: discord.Guild, user: discord.User):
-        # if a member gets unbanned, we check if he was temp banned with warnsystem
-        # if it was, we remove the case so it won't unban him a second time
+        # if a member gets unbanned, we check if they were temp banned with warnsystem
+        # if it was, we remove the case so it won't unban them a second time
         warns = await self.cache.get_temp_action(guild)
         to_remove = []  # there can be multiple temp bans, let's not question the moderators
         for member, data in warns.items():
@@ -1348,7 +1348,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
             await self.cache.bulk_remove_temp_action(guild, to_remove)
             log.info(
                 f"[Guild {guild.id}] The temporary ban of user {user} (ID: {user.id}) "
-                "was cancelled due to his manual unban."
+                "was cancelled due to their manual unban."
             )
 
     @listener()
@@ -1501,7 +1501,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
             "- Warn author (responsible moderator. can be the bot in case of automated warns)\n"
             "- Date and time of the warn\n"
             "- Duration of the warn (only in case of a temporary mute/ban)\n"
-            "- List of the roles the member had when he was muted "
+            "- List of the roles the member had when they were muted "
             "(only for mutes since version 1.2)\n\n"
             "A list of files is provided, one for each server. The ID of the server is the name "
             "of the file. Servers without registered warnings are not included.\n\n"


### PR DESCRIPTION
## Pull request type

<!-- Short description of what this pull request is (new feature, bug fix, enhancement...) -->

Enhancement

## Description of the changes

Replace usage of he/him/his with they/them/theirs when referring to general users. Every change was manually checked to ensure correct surrounding grammar, and that specific people's pronouns in examples and credits were not changed.

Change bot to be referred to as it instead of he in a few places.

Fix a few typos I noticed while making the above changes.

<!--
## Check-list

If useful, make a bullet list of the things done or not (will show up in the PR list). Example:

- [x] Do thing 1
- [x] Do thing 2
- [ ] Testing
- [ ] Docs
-->
