### PR TITLE
Fix banned member warnings display

### DIFF
--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -756,7 +756,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                 msg.append(f"{warning_str(i, total_warns > 1)}: {total_warns}")
         warn_field = "\n".join(msg) if len(msg) > 1 else msg[0]
         embed = discord.Embed(description=_("User modlog summary."))
-        embed.set_author(name=f"{user} | {user.id}", icon_url=user.avatar.url)
+        embed.set_author(name=f"{user} | {user.id}", icon_url=user.display_avatar)
         embed.add_field(
             name=_("Total number of warnings: ") + str(len(cases)), value=warn_field, inline=False
         )


### PR DESCRIPTION
## Pull request type

Bug fix

## Description of the changes

Fixes console error listed in #211 where by running `!warnings` against banned members, it fails due to invalid avatar lookup methods.

<!--
## Check-list

No change necessary, restoring functionality to previously available commands.

-->
