### PR TITLE
Fix automod timezone-awareness inconsistency causing errors

### DIFF
--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -1764,7 +1764,7 @@ class API:
         found_warnings = {}  # we fill this list with the valid autowarns, there can be more than 1
         for warn in warns[::-1]:
             to_remove = []  # list of autowarns to remove during the iteration (duration expired)
-            taken_on = datetime.fromtimestamp(warn["time"])
+            taken_on = datetime.fromtimestamp(warn["time"], timezone.utc)
             for i, autowarn in enumerate(autowarns):
                 try:
                     if autowarn["until"] >= taken_on:


### PR DESCRIPTION
## Pull request type

One-line bug fix
<!-- Short description of what this pull request is (new feature, bug fix, enhancement...) -->

## Description of the changes

This fixes [the error](https://discord.com/channels/240154543684321280/621802281733586975/1180622593393442947) preventing automod from working because one timestamp in a comparison is offset-aware and the other is offset-naive. I changed it so the offset-naive one is also offset-aware (UTC). I think this is correct because I assume it's originally set as UTC rather than local time, but I'm not familiar enough with the code to know for sure.

In my testing this successfully prevented the "TypeError: can't compare offset-naive and offset-aware datetimes" issue. I also additionally had to nuke the config and start over for automod mutes to actually *work*, but that is probably some other issue that may have been in my configuration.

<!--
## Check-list

If useful, make a bullet list of the things done or not (will show up in the PR list). Example:

- [x] Do thing 1
- [x] Do thing 2
- [ ] Testing
- [ ] Docs
-->
