### PR TITLE
[WarnSystem] Replace role mute system, with Discord built-in timeouts

### DIFF
--- a/warnsystem/README.md
+++ b/warnsystem/README.md
@@ -2,7 +2,7 @@
 
 This is the WarnSystem cog for Red, rewrite of the V2 cog, BetterMod. It is an alternative to the core moderation system of Red, similar to Dyno. You can warn members up to 5 levels:
 1. simple warning
-2. mute (can be a temporary mute)
+2. timeout
 3. kick
 4. softban (ban then unban, which can cleanup the messages of an user up to a week)
 5. ban (can be a temporary ban, or even a hack ban, which allows you to ban on an user not on the server)
@@ -42,20 +42,14 @@ The cog is highly customizable and frequently updated. It's also built with an A
     ```
     *Note: If you already set a modlog channel with the modlogs cog, it will be used if you skip this part.*
 
-5.  Setup a mute role. **This might take a long time, depending on the number of text channels on your server.**
-    ```
-    [p]warnset mute
-    ```
-    The mutes are done with a role. Feel free to edit its permissions, but make sure it stays under the bot's top role!
+5. (Optional) Import your data from BetterMod.
 
-6.  (Optional) Import your data from BetterMod.
-
-    **You must have the latest version of BetterMod before using this command. Using an outdated body will break the data of the cog!**
+   **You must have the latest version of BetterMod before using this command. Using an outdated body will break the data of the cog!**
 
     1.  Grab your server ID. To get this, you can either:
         -   Use the `[p]serverinfo` command in the General cog.
         -   Enable the developer mode (User settings > Appearance), right click on your server, then click  "Copy ID"
-    
+
     2.  Go to your V2 bot's directory, and navigate to `data/bettermod/history/` and find the file which name is your server ID, and copy its full path.
 
     3.  Type this command: `[p]warnset convert <path_to_file>`

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -347,7 +347,6 @@ class API:
                         "level"     : int,  # between 1 and 5, the warning level
                         "author"    : Union[discord.Member, str],  # the member that warned the user
                         "reason"    : Optional[str],  # the reason of the warn, can be None
-                        "reason"    : Optional[str],  # the reason of the warn, can be None
                         "time"      : datetime.datetime,  # the date when the warn was set
                     },
                     {

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -913,7 +913,8 @@ class API:
             The level must be an :py:class:`int` between 1 and 5.
         ~warnsystem.errors.BadArgument
             You need to provide a valid :class:`discord.Member` object, except for a
-            hackban where a :class:`discord.User` works.
+            hackban where a :class:`discord.User` works or you missing a max. 28 day time
+            when setting a timeout.
         ~warnsystem.errors.LostPermissions
             The bot lost a permission to do something (it had the perm before). This
             can be lost permissions for sending messages to the modlog channel

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -244,22 +244,22 @@ class API:
         return True
 
     async def _create_case(
-            self,
-            guild: discord.Guild,
-            user: discord.User,
-            author: Union[discord.Member, str],
-            level: int,
-            time: datetime,
-            reason: Optional[str] = None,
-            duration: Optional[timedelta] = None,
-            modlog_message: Optional[discord.Message] = None,
+        self,
+        guild: discord.Guild,
+        user: discord.User,
+        author: Union[discord.Member, str],
+        level: int,
+        time: datetime,
+        reason: Optional[str] = None,
+        duration: Optional[timedelta] = None,
+        modlog_message: Optional[discord.Message] = None,
     ) -> dict:
         """Create a new case for a member. Don't call this, call warn instead."""
         data = {
             "level": level,
-            "author": author
-            if not isinstance(author, (discord.User, discord.Member))
-            else author.id,
+            "author": (
+                author if not isinstance(author, (discord.User, discord.Member)) else author.id
+            ),
             "reason": reason,
             "time": int(time.timestamp()),  # seconds since epoch
             "duration": None if not duration else duration.total_seconds(),
@@ -274,7 +274,7 @@ class API:
         return data
 
     async def get_case(
-            self, guild: discord.Guild, user: Union[discord.User, discord.Member], index: int
+        self, guild: discord.Guild, user: Union[discord.User, discord.Member], index: int
     ) -> dict:
         """
         Get a specific case for a user.
@@ -319,7 +319,7 @@ class API:
             return case
 
     async def get_all_cases(
-            self, guild: discord.Guild, user: Optional[Union[discord.User, discord.Member]] = None
+        self, guild: discord.Guild, user: Optional[Union[discord.User, discord.Member]] = None
     ) -> list:
         """
         Get all cases for a member of a guild.
@@ -392,11 +392,11 @@ class API:
         return sorted(all_cases, key=lambda x: x["time"])  # sorted from oldest to newest
 
     async def edit_case(
-            self,
-            guild: discord.Guild,
-            user: Union[discord.User, discord.Member],
-            index: int,
-            new_reason: str,
+        self,
+        guild: discord.Guild,
+        user: Union[discord.User, discord.Member],
+        index: int,
+        new_reason: str,
     ) -> bool:
         """
         Edit the reason of a case.
@@ -496,10 +496,10 @@ class API:
         return True
 
     async def delete_case(
-            self,
-            guild: discord.Guild,
-            user: Union[discord.Member, UnavailableMember],
-            index: int,
+        self,
+        guild: discord.Guild,
+        user: Union[discord.Member, UnavailableMember],
+        index: int,
     ):
         async def delete_message(channel_id: int, message_id: int):
             channel: discord.TextChannel = guild.get_channel(channel_id)
@@ -552,7 +552,7 @@ class API:
         return True
 
     async def get_modlog_channel(
-            self, guild: discord.Guild, level: Optional[Union[int, str]] = None
+        self, guild: discord.Guild, level: Optional[Union[int, str]] = None
     ) -> discord.TextChannel:
         """
         Get the WarnSystem's modlog channel on the current guild.
@@ -635,15 +635,15 @@ class API:
         return self.bot.get_channel(channel if channel else default_channel)
 
     async def get_embeds(
-            self,
-            guild: discord.Guild,
-            member: Union[discord.Member, UnavailableMember],
-            author: Union[discord.Member, str],
-            level: int,
-            reason: Optional[str] = None,
-            time: Optional[timedelta] = None,
-            date: Optional[datetime] = None,
-            message_sent: bool = True,
+        self,
+        guild: discord.Guild,
+        member: Union[discord.Member, UnavailableMember],
+        author: Union[discord.Member, str],
+        level: int,
+        reason: Optional[str] = None,
+        time: Optional[timedelta] = None,
+        date: Optional[datetime] = None,
+        message_sent: bool = True,
     ) -> tuple:
         """
         Return two embeds, one for the modlog and one for the member.
@@ -693,7 +693,7 @@ class API:
         # prepare the status field
         total_warns = len(logs) + 1
         total_type_warns = (
-                len([x for x in logs if x["level"] == level]) + 1
+            len([x for x in logs if x["level"] == level]) + 1
         )  # number of warns of the received type
 
         # a lambda that returns a string; if True is given, a third person sentence is returned
@@ -794,7 +794,6 @@ class API:
 
         return (log_embed, user_embed)
 
-
     async def format_reason(self, guild: discord.Guild, reason: str = None) -> str:
         """
         Reformat a reason with the substitutions set on the guild.
@@ -819,20 +818,20 @@ class API:
         return reason
 
     async def warn(
-            self,
-            guild: discord.Guild,
-            members: Iterable[Union[discord.Member, UnavailableMember]],
-            author: Union[discord.Member, str],
-            level: int,
-            reason: Optional[str] = None,
-            time: Optional[timedelta] = None,
-            date: Optional[datetime] = None,
-            ban_days: Optional[int] = None,
-            log_modlog: Optional[bool] = True,
-            log_dm: Optional[bool] = True,
-            take_action: Optional[bool] = True,
-            automod: Optional[bool] = True,
-            progress_tracker: Optional[Callable[[int], Awaitable[None]]] = None,
+        self,
+        guild: discord.Guild,
+        members: Iterable[Union[discord.Member, UnavailableMember]],
+        author: Union[discord.Member, str],
+        level: int,
+        reason: Optional[str] = None,
+        time: Optional[timedelta] = None,
+        date: Optional[datetime] = None,
+        ban_days: Optional[int] = None,
+        log_modlog: Optional[bool] = True,
+        log_dm: Optional[bool] = True,
+        take_action: Optional[bool] = True,
+        automod: Optional[bool] = True,
+        progress_tracker: Optional[Callable[[int], Awaitable[None]]] = None,
     ) -> bool:
         """
         Set a warning on a member of a Discord guild and log it with the WarnSystem system.
@@ -944,8 +943,8 @@ class API:
                     ).format(bot_role=guild.me.top_role.name, member_role=member.top_role.name)
                 )
             if await self.data.guild(guild).respect_hierarchy() and (
-                    not (await self.bot.is_owner(author) or author.id == guild.owner_id)
-                    and member.top_role.position >= author.top_role.position
+                not (await self.bot.is_owner(author) or author.id == guild.owner_id)
+                and member.top_role.position >= author.top_role.position
             ):
                 return errors.NotAllowedByHierarchy(
                     "The moderator is lower than the member in the servers's role hierarchy."
@@ -1008,10 +1007,10 @@ class API:
                             member,
                             reason=audit_reason,
                             delete_message_seconds=(
-                                                           ban_days or await self.data.guild(guild).bandays.softban()
-                                                   )
-                                                   * 24
-                                                   * 3600,
+                                ban_days or await self.data.guild(guild).bandays.softban()
+                            )
+                            * 24
+                            * 3600,
                         )
                         await guild.unban(
                             member,
@@ -1024,10 +1023,10 @@ class API:
                             member,
                             reason=audit_reason,
                             delete_message_seconds=(
-                                                           ban_days or await self.data.guild(guild).bandays.ban()
-                                                   )
-                                                   * 24
-                                                   * 3600,
+                                ban_days or await self.data.guild(guild).bandays.ban()
+                            )
+                            * 24
+                            * 3600,
                         )
                 except discord.errors.HTTPException as e:
                     log.warn(
@@ -1041,7 +1040,9 @@ class API:
                 modlog_message = await mod_channel.send(embed=modlog_e)
             else:
                 modlog_message = None
-            data = await self._create_case(guild, member, author, level, date, reason, time, modlog_message)
+            data = await self._create_case(
+                guild, member, author, level, date, reason, time, modlog_message
+            )
             # start timer if there is a temporary warning
             if time and level == 5:
                 await self._start_timer(guild, member, data)
@@ -1072,7 +1073,7 @@ class API:
         # we check for all permission problem that can occur before calling the API
         # checks if the bot has send_messages and embed_links permissions in modlog channel
         if not (
-                guild.me.guild_permissions.send_messages and guild.me.guild_permissions.embed_links
+            guild.me.guild_permissions.send_messages and guild.me.guild_permissions.embed_links
         ):
             raise errors.LostPermissions(
                 _(
@@ -1466,9 +1467,9 @@ class API:
         # we cleanup their x last messages (max_messages + 1), then either send a text warn
         # or perform an actual warnsystem warn (I'm confusing ik)
         if (
-                data.warned is False
-                or (datetime.now() - data.warned).total_seconds()
-                < antispam_data["delay_before_action"]
+            data.warned is False
+            or (datetime.now() - data.warned).total_seconds()
+            < antispam_data["delay_before_action"]
         ):
             bot_message = await channel.send(
                 _("{member} you're sending messages too fast!").format(member=member.mention),
@@ -1503,7 +1504,7 @@ class API:
         return new_list
 
     def _automod_clean_cache(
-            self, guild: discord.Guild, channel: discord.TextChannel, member: discord.Member
+        self, guild: discord.Guild, channel: discord.TextChannel, member: discord.Member
     ):
         """
         We quickly end up with a dict filled with empty values, we gotta clean that.
@@ -1515,7 +1516,7 @@ class API:
                 del self.automod[guild.id]
 
     async def automod_check_for_autowarn(
-            self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
+        self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
     ):
         """
         Iterate through member's modlog, looking for possible automatic warns.
@@ -1541,7 +1542,7 @@ class API:
             )
 
     async def _automod_check_for_autowarn(
-            self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
+        self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
     ):
         """
         Prevents having to put this whole function into a try/except block.

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -237,62 +237,22 @@ class API:
         return string
 
     async def _start_timer(self, guild: discord.Guild, member: discord.Member, case: dict) -> bool:
-        """Start the timer for a temporary mute/ban."""
+        """Start the timer for a temporary ban."""
         if not case["duration"]:
             raise errors.BadArgument("No duration for this warning!")
         await self.cache.add_temp_action(guild, member, case)
         return True
 
-    async def _mute(self, member: discord.Member, reason: Optional[str] = None):
-        """Mute an user on the guild."""
-        old_roles = []
-        guild = member.guild
-        mute_role = guild.get_role(await self.cache.get_mute_role(guild))
-        remove_roles = await self.data.guild(guild).remove_roles()
-        if not mute_role:
-            raise errors.MissingMuteRole("You need to create the mute role before doing this.")
-        if remove_roles:
-            old_roles = member.roles.copy()
-            old_roles.remove(guild.default_role)
-            old_roles = [
-                x for x in old_roles if x.position < guild.me.top_role.position and not x.managed
-            ]
-            fails = []
-            for role in old_roles:
-                try:
-                    await member.remove_roles(role, reason=reason)
-                except discord.errors.HTTPException:
-                    fails.append(role)
-            if fails:
-                log.warn(
-                    f"[Guild {guild.id}] Failed to remove roles from {member} (ID: {member.id}) "
-                    f"while muting. Roles: {', '.join([f'{x.name} ({x.id})' for x in fails])}",
-                )
-        await member.add_roles(mute_role, reason=reason)
-        return old_roles
-
-    async def _unmute(self, member: discord.Member, reason: str, old_roles: list = None):
-        """Unmute an user on the guild."""
-        guild = member.guild
-        mute_role = guild.get_role(await self.cache.get_mute_role(guild))
-        if not mute_role:
-            raise errors.MissingMuteRole(
-                f"Lost the mute role on guild {guild.name} (ID: {guild.id}"
-            )
-        await member.remove_roles(mute_role, reason=reason)
-        await member.add_roles(*old_roles, reason=reason)
-
     async def _create_case(
-        self,
-        guild: discord.Guild,
-        user: discord.User,
-        author: Union[discord.Member, str],
-        level: int,
-        time: datetime,
-        reason: Optional[str] = None,
-        duration: Optional[timedelta] = None,
-        roles: Optional[list] = None,
-        modlog_message: Optional[discord.Message] = None,
+            self,
+            guild: discord.Guild,
+            user: discord.User,
+            author: Union[discord.Member, str],
+            level: int,
+            time: datetime,
+            reason: Optional[str] = None,
+            duration: Optional[timedelta] = None,
+            modlog_message: Optional[discord.Message] = None,
     ) -> dict:
         """Create a new case for a member. Don't call this, call warn instead."""
         data = {
@@ -303,7 +263,6 @@ class API:
             "reason": reason,
             "time": int(time.timestamp()),  # seconds since epoch
             "duration": None if not duration else duration.total_seconds(),
-            "roles": [] if not roles else [x.id for x in roles],
         }
         if modlog_message:
             data["modlog_message"] = {
@@ -315,7 +274,7 @@ class API:
         return data
 
     async def get_case(
-        self, guild: discord.Guild, user: Union[discord.User, discord.Member], index: int
+            self, guild: discord.Guild, user: Union[discord.User, discord.Member], index: int
     ) -> dict:
         """
         Get a specific case for a user.
@@ -360,7 +319,7 @@ class API:
             return case
 
     async def get_all_cases(
-        self, guild: discord.Guild, user: Optional[Union[discord.User, discord.Member]] = None
+            self, guild: discord.Guild, user: Optional[Union[discord.User, discord.Member]] = None
     ) -> list:
         """
         Get all cases for a member of a guild.
@@ -433,11 +392,11 @@ class API:
         return sorted(all_cases, key=lambda x: x["time"])  # sorted from oldest to newest
 
     async def edit_case(
-        self,
-        guild: discord.Guild,
-        user: Union[discord.User, discord.Member],
-        index: int,
-        new_reason: str,
+            self,
+            guild: discord.Guild,
+            user: Union[discord.User, discord.Member],
+            index: int,
+            new_reason: str,
     ) -> bool:
         """
         Edit the reason of a case.
@@ -537,10 +496,10 @@ class API:
         return True
 
     async def delete_case(
-        self,
-        guild: discord.Guild,
-        user: Union[discord.Member, UnavailableMember],
-        index: int,
+            self,
+            guild: discord.Guild,
+            user: Union[discord.Member, UnavailableMember],
+            index: int,
     ):
         async def delete_message(channel_id: int, message_id: int):
             channel: discord.TextChannel = guild.get_channel(channel_id)
@@ -581,23 +540,7 @@ class API:
                 return False
             return True
 
-        case = await self.get_case(guild, user, index)
-        can_unmute = False
-        add_roles = False
-        if case["level"] == 2:
-            mute_role = guild.get_role(await self.cache.get_mute_role(guild))
-            member = guild.get_member(user)
-            if member:
-                if mute_role and mute_role in member.roles:
-                    can_unmute = True
-                add_roles = await self.data.guild(guild).remove_roles()
-        if can_unmute:
-            await member.remove_roles(mute_role, reason=_("Warning deleted."))
         async with self.data.custom("MODLOGS", guild.id, user.id).x() as logs:
-            try:
-                roles = logs[index - 1]["roles"]
-            except KeyError:
-                roles = []
             try:
                 channel_id, message_id = logs[index - 1]["modlog_message"].values()
             except KeyError:
@@ -605,14 +548,11 @@ class API:
             else:
                 await delete_message(channel_id, message_id)
             logs.remove(logs[index - 1])
-        if add_roles and roles:
-            roles = [guild.get_role(x) for x in roles]
-            await member.add_roles(*roles, reason=_("Adding removed roles back after unmute."))
         log.debug(f"[Guild {guild.id}] Removed case #{index} from member {user} (ID: {user.id}).")
         return True
 
     async def get_modlog_channel(
-        self, guild: discord.Guild, level: Optional[Union[int, str]] = None
+            self, guild: discord.Guild, level: Optional[Union[int, str]] = None
     ) -> discord.TextChannel:
         """
         Get the WarnSystem's modlog channel on the current guild.
@@ -695,15 +635,15 @@ class API:
         return self.bot.get_channel(channel if channel else default_channel)
 
     async def get_embeds(
-        self,
-        guild: discord.Guild,
-        member: Union[discord.Member, UnavailableMember],
-        author: Union[discord.Member, str],
-        level: int,
-        reason: Optional[str] = None,
-        time: Optional[timedelta] = None,
-        date: Optional[datetime] = None,
-        message_sent: bool = True,
+            self,
+            guild: discord.Guild,
+            member: Union[discord.Member, UnavailableMember],
+            author: Union[discord.Member, str],
+            level: int,
+            reason: Optional[str] = None,
+            time: Optional[timedelta] = None,
+            date: Optional[datetime] = None,
+            message_sent: bool = True,
     ) -> tuple:
         """
         Return two embeds, one for the modlog and one for the member.
@@ -726,7 +666,7 @@ class API:
         reason: Optional[str]
             The reason of the warning.
         time: Optional[timedelta]
-            The time before the action ends. Only for mute and ban.
+            The time before the action ends. Only for timeout and ban.  # TODO: Change text, since it's required by timeouts
         date: Optional[datetime]
             When the action was taken.
         message_sent: bool
@@ -739,7 +679,7 @@ class API:
         """
         action = {
             1: (_("warn"), _("warns")),
-            2: (_("mute"), _("mutes")),
+            2: (_("timeout"), _("timeouts")),
             3: (_("kick"), _("kicks")),
             4: (_("softban"), _("softbans")),
             5: (_("ban"), _("bans")),
@@ -753,7 +693,7 @@ class API:
         # prepare the status field
         total_warns = len(logs) + 1
         total_type_warns = (
-            len([x for x in logs if x["level"] == level]) + 1
+                len([x for x in logs if x["level"] == level]) + 1
         )  # number of warns of the received type
 
         # a lambda that returns a string; if True is given, a third person sentence is returned
@@ -854,105 +794,6 @@ class API:
 
         return (log_embed, user_embed)
 
-    async def maybe_create_mute_role(self, guild: discord.Guild) -> bool:
-        """
-        Create the mod role for WarnSystem if it doesn't exist.
-        This will also edit all channels to deny the following permissions to this role:
-
-        *   ``send_messages``
-        *   ``add_reactions``
-        *   ``speak``
-
-        Parameters
-        ----------
-        guild: discord.Guild
-            The guild you want to set up the mute in.
-
-        Returns
-        -------
-        Union[bool, list]
-            *   :py:obj:`False` if the role already exists.
-            *   :py:class:`list` if the role was created, with a list of errors for each channel.
-                Empty list means completly successful edition.
-
-        Raises
-        ------
-        ~warnsystem.errors.MissingPermissions
-            The bot lacks the :attr:`discord.Permissions.create_roles` permission.
-        discord.errors.HTTPException
-            Creating the role failed.
-        """
-        role = await self.cache.get_mute_role(guild)
-        role = guild.get_role(role)
-        if role:
-            return False
-
-        if not guild.me.guild_permissions.manage_roles:
-            raise errors.MissingPermissions(
-                _("I can't manage roles, please give me this permission to continue.")
-            )
-
-        # no mod role on this guild, let's create one
-        role = await guild.create_role(
-            name="Muted",
-            reason=_(
-                "WarnSystem mute role. This role will be assigned to the muted members, "
-                "feel free to move it or modify its channel permissions."
-            ),
-        )
-        await asyncio.sleep(0.5)  # prevents an error when repositionning the role
-        await role.edit(
-            position=guild.me.top_role.position - 1,
-            reason=_(
-                "Modifying role's position, keep it under my top role so "
-                "I can add it to muted members."
-            ),
-        )
-        perms = discord.PermissionOverwrite(send_messages=False, add_reactions=False, speak=False)
-        errors = []
-        for channel in guild.channels:
-            try:
-                await channel.set_permissions(
-                    target=role,
-                    overwrite=perms,
-                    reason=_(
-                        "Setting up WarnSystem mute. All muted members will have this role, "
-                        "feel free to edit its permissions."
-                    ),
-                )
-            except discord.errors.Forbidden:
-                errors.append(
-                    _(
-                        "Cannot edit permissions of the channel {channel} because of a "
-                        "permission error (probably enforced permission for `Manage channel`)."
-                    ).format(channel=channel.mention)
-                )
-            except discord.errors.HTTPException as e:
-                errors.append(
-                    _(
-                        "Cannot edit permissions of the channel {channel} because of "
-                        "an unknown error."
-                    ).format(channel=channel.mention)
-                )
-                log.warn(
-                    f"[Guild {guild.id}] Couldn't edit permissions of {channel} (ID: "
-                    f"{channel.id}) for setting up the mute role because of an HTTPException.",
-                    exc_info=e,
-                )
-            except Exception as e:
-                errors.append(
-                    _(
-                        "Cannot edit permissions of the channel {channel} because of "
-                        "an unknown error."
-                    ).format(channel=channel.mention)
-                )
-                log.error(
-                    f"[Guild {guild.id}] Couldn't edit permissions of {channel} (ID: "
-                    f"{channel.id}) for setting up the mute role because of an unknwon error.",
-                    exc_info=e,
-                )
-        await self.cache.update_mute_role(guild, role)
-        return errors
 
     async def format_reason(self, guild: discord.Guild, reason: str = None) -> str:
         """
@@ -978,20 +819,20 @@ class API:
         return reason
 
     async def warn(
-        self,
-        guild: discord.Guild,
-        members: Iterable[Union[discord.Member, UnavailableMember]],
-        author: Union[discord.Member, str],
-        level: int,
-        reason: Optional[str] = None,
-        time: Optional[timedelta] = None,
-        date: Optional[datetime] = None,
-        ban_days: Optional[int] = None,
-        log_modlog: Optional[bool] = True,
-        log_dm: Optional[bool] = True,
-        take_action: Optional[bool] = True,
-        automod: Optional[bool] = True,
-        progress_tracker: Optional[Callable[[int], Awaitable[None]]] = None,
+            self,
+            guild: discord.Guild,
+            members: Iterable[Union[discord.Member, UnavailableMember]],
+            author: Union[discord.Member, str],
+            level: int,
+            reason: Optional[str] = None,
+            time: Optional[timedelta] = None,
+            date: Optional[datetime] = None,
+            ban_days: Optional[int] = None,
+            log_modlog: Optional[bool] = True,
+            log_dm: Optional[bool] = True,
+            take_action: Optional[bool] = True,
+            automod: Optional[bool] = True,
+            progress_tracker: Optional[Callable[[int], Awaitable[None]]] = None,
     ) -> bool:
         """
         Set a warning on a member of a Discord guild and log it with the WarnSystem system.
@@ -1019,14 +860,14 @@ class API:
             An :py:class:`int` between 1 and 5, specifying the warning level:
 
             #.  Simple DM warning
-            #.  Mute (can be temporary)
+            #.  Timeout
             #.  Kick
             #.  Softban
             #.  Ban (can be temporary ban, or hack ban, if the member is not in the server)
         reason: Optional[str]
             The optional reason of the warning. It is strongly recommanded to set one.
         time: Optional[timedelta]
-            The time before cancelling the action. This only works for a mute or a ban.
+            The time before cancelling the action. This only works for a timeout or a ban.
         date: Optional[datetime]
             When the action was taken. Only use if you want to overwrite the current date and time.
         ban_days: Optional[int]
@@ -1037,7 +878,7 @@ class API:
         log_dm: Optional[bool]
             Specify if an embed should be sent to the warned user. Default to :py:obj:`True`.
         take_action: Optional[bool]
-            Specify if the bot should take action on the member (mute, kick, softban, ban). If set
+            Specify if the bot should take action on the member (timeout, kick, softban, ban). If set
             to :py:obj:`False`, the bot will only send a log embed to the member and in the modlog.
             Default to :py:obj:`True`.
         automod: Optional[bool]
@@ -1074,20 +915,12 @@ class API:
         ~warnsystem.errors.BadArgument
             You need to provide a valid :class:`discord.Member` object, except for a
             hackban where a :class:`discord.User` works.
-        ~warnsystem.errors.MissingMuteRole
-            You're trying to mute someone but the mute role was not setup yet.
-            You can fix this by calling :func:`~warnsystem.api.API.maybe_create_mute_role`.
         ~warnsystem.errors.LostPermissions
             The bot lost a permission to do something (it had the perm before). This
-            can be lost permissions for sending messages to the modlog channel or
-            interacting with the mute role.
+            can be lost permissions for sending messages to the modlog channel
         ~warnsystem.errors.MemberTooHigh
             The bot is trying to take actions on someone but their top role is higher
             than the bot's top role in the guild's hierarchy.
-        ~warnsystem.errors.NotAllowedByHierarchy
-            The moderator trying to warn someone is lower than them in the role hierarchy,
-            while the bot still has permissions to act. This is raised only if the
-            hierarchy check is enabled.
         ~warnsystem.errors.MissingPermissions
             The bot lacks a permissions to do something. Can be adding role, kicking
             or banning members.
@@ -1100,7 +933,6 @@ class API:
 
         async def warn_member(member: Union[discord.Member, UnavailableMember], audit_reason: str):
             nonlocal i
-            roles = []
             # permissions check
             if level > 1 and guild.me.top_role.position <= member.top_role.position:
                 # check if the member is below the bot in the roles's hierarchy
@@ -1112,8 +944,8 @@ class API:
                     ).format(bot_role=guild.me.top_role.name, member_role=member.top_role.name)
                 )
             if await self.data.guild(guild).respect_hierarchy() and (
-                not (await self.bot.is_owner(author) or author.id == guild.owner_id)
-                and member.top_role.position >= author.top_role.position
+                    not (await self.bot.is_owner(author) or author.id == guild.owner_id)
+                    and member.top_role.position >= author.top_role.position
             ):
                 return errors.NotAllowedByHierarchy(
                     "The moderator is lower than the member in the servers's role hierarchy."
@@ -1122,6 +954,7 @@ class API:
                 return errors.MissingPermissions(
                     _("I can't take actions on the owner of the guild.")
                 )
+            # TODO: We probably need to ensure here, that time is present for timeouts
             if member == guild.me:
                 return errors.SuicidePrevention(
                     _(
@@ -1137,6 +970,9 @@ class API:
             if log_dm:
                 try:
                     await member.send(embed=user_e)
+                    ban_appeals_timer = self.bot.get_cog("BanAppealsTimer")
+                    if level == 5 and ban_appeals_timer:
+                        await ban_appeals_timer.send_ban_appeal_link(member, reason)
                 except (discord.errors.Forbidden, errors.UserNotFound):
                     modlog_e = (
                         await self.get_embeds(
@@ -1161,7 +997,7 @@ class API:
                 audit_reason = audit_reason.format(member=member)
                 try:
                     if level == 2:
-                        roles = await self._mute(member, audit_reason)
+                        await member.timeout(time, reason=audit_reason)
                     elif level == 3:
                         await guild.kick(member, reason=audit_reason)
                     elif level == 4:
@@ -1169,10 +1005,10 @@ class API:
                             member,
                             reason=audit_reason,
                             delete_message_seconds=(
-                                ban_days or await self.data.guild(guild).bandays.softban()
-                            )
-                            * 24
-                            * 3600,
+                                                           ban_days or await self.data.guild(guild).bandays.softban()
+                                                   )
+                                                   * 24
+                                                   * 3600,
                         )
                         await guild.unban(
                             member,
@@ -1185,10 +1021,10 @@ class API:
                             member,
                             reason=audit_reason,
                             delete_message_seconds=(
-                                ban_days or await self.data.guild(guild).bandays.ban()
-                            )
-                            * 24
-                            * 3600,
+                                                           ban_days or await self.data.guild(guild).bandays.ban()
+                                                   )
+                                                   * 24
+                                                   * 3600,
                         )
                 except discord.errors.HTTPException as e:
                     log.warn(
@@ -1202,11 +1038,9 @@ class API:
                 modlog_message = await mod_channel.send(embed=modlog_e)
             else:
                 modlog_message = None
-            data = await self._create_case(
-                guild, member, author, level, date, reason, time, roles, modlog_message
-            )
+            data = await self._create_case(guild, member, author, level, date, reason, time, modlog_message)
             # start timer if there is a temporary warning
-            if time and (level == 2 or level == 5):
+            if time and level == 5:
                 await self._start_timer(guild, member, data)
             if automod:
                 # This function can be pretty heavy, and the response can be seriously delayed
@@ -1232,14 +1066,10 @@ class API:
         # we get the modlog channel now to make sure it exists before doing anything
         if log_modlog:
             mod_channel = await self.get_modlog_channel(guild, level)
-        # check if the mute role exists
-        mute_role = guild.get_role(await self.cache.get_mute_role(guild))
-        if not mute_role and level == 2:
-            raise errors.MissingMuteRole("You need to create the mute role before doing this.")
         # we check for all permission problem that can occur before calling the API
         # checks if the bot has send_messages and embed_links permissions in modlog channel
         if not (
-            guild.me.guild_permissions.send_messages and guild.me.guild_permissions.embed_links
+                guild.me.guild_permissions.send_messages and guild.me.guild_permissions.embed_links
         ):
             raise errors.LostPermissions(
                 _(
@@ -1248,17 +1078,9 @@ class API:
                 ).format(channel=mod_channel.mention)
             )
         if level == 2:
-            # mute with role
-            if not guild.me.guild_permissions.manage_roles:
+            if not guild.me.guild_permissions.moderate_members:
                 raise errors.MissingPermissions(
-                    _("I can't manage roles, please give me this permission to continue.")
-                )
-            if mute_role.position >= guild.me.top_role.position:
-                raise errors.LostPermissions(
-                    _(
-                        "The mute role `{mute_role}` was moved above my top role `{my_role}`. "
-                        "Please move the roles so my top role is above the mute role."
-                    ).format(mute_role=mute_role.name, my_role=guild.me.top_role.name)
+                    _("I can't timeout members, please give me this permission to continue.")
                 )
         if level == 3:
             # kick
@@ -1273,7 +1095,7 @@ class API:
                     _("I can't ban members, please give me this permission to continue.")
                 )
 
-        action = {1: _("warn"), 2: _("mute"), 3: _("kick"), 4: _("softban"), 5: _("ban")}.get(
+        action = {1: _("warn"), 2: _("timeout"), 3: _("kick"), 4: _("softban"), 5: _("ban")}.get(
             level, _("unknown")
         )
         audit_reason = _(
@@ -1362,13 +1184,9 @@ class API:
                 member = guild.get_member(member_id)
                 case_reason = action["reason"]
                 level = action["level"]
-                action_str = _("mute") if level == 2 else _("ban")
+                action_str = _("ban")
                 if not member:
                     member = UnavailableMember(self.bot, guild._state, member_id)
-                    if level == 2:
-                        to_remove.append(member)
-                        continue
-                roles = list(filter(None, [guild.get_role(x) for x in action.get("roles") or []]))
 
                 reason = _(
                     "End of timed {action} of {member} requested by {author} that lasted "
@@ -1383,8 +1201,6 @@ class API:
                 if (taken_on + duration) < now:
                     # end of warn
                     try:
-                        if level == 2:
-                            await self._unmute(member, reason=reason, old_roles=roles)
                         if level == 5:
                             await guild.unban(member, reason=reason)
                             if await self.data.guild(guild).reinvite():
@@ -1423,14 +1239,14 @@ class API:
     async def _loop_task(self):
         """
         This is an infinite loop task started with the cog that will check\
-        if a temporary warn (mute or ban) is over, and cancel the action if it's true.
+        if a temporary warn (ban) is over, and cancel the action if it's true.
 
         The loop runs every 10 seconds.
         """
         await self.bot.wait_until_ready()
         log.debug(
-            "Starting infinite loop for unmutes and unbans. Canel the "
-            'task with bot.get_cog("WarnSystem").task.cancel()'
+            "Starting infinite loop for unbans. Canel the task with "
+            'bot.get_cog("WarnSystem").task.cancel()'
         )
         errors = 0
         while True:
@@ -1441,16 +1257,14 @@ class API:
                 if errors >= 3:
                     # more than 3 errors in our loop, let's shut down the loop
                     log.critical(
-                        "The loop for unmutes and unbans encountered a third error. To prevent "
-                        "more damages, the loop will be cancelled. Timed mutes and bans no longer "
-                        "works for now. Reload the cog to start the loop back. If the problem "
-                        "persists, report the error and update the cog.",
+                        "The loop for unbans encountered a third error. To prevent "
+                        "more damages, the loop will be cancelled. Bans no longer works for "
+                        "now. Reload the cog to start the loop back. If the problem persists, "
+                        "report the error and update the cog.",
                         exc_info=e,
                     )
                     return
-                log.error(
-                    "Error in loop for unmutes and unbans. The loop will be resumed.", exc_info=e
-                )
+                log.error("Error in loop for unbans. The loop will be resumed.", exc_info=e)
             await asyncio.sleep(10)
 
     # automod stuff
@@ -1649,9 +1463,9 @@ class API:
         # we cleanup their x last messages (max_messages + 1), then either send a text warn
         # or perform an actual warnsystem warn (I'm confusing ik)
         if (
-            data.warned is False
-            or (datetime.now() - data.warned).total_seconds()
-            < antispam_data["delay_before_action"]
+                data.warned is False
+                or (datetime.now() - data.warned).total_seconds()
+                < antispam_data["delay_before_action"]
         ):
             bot_message = await channel.send(
                 _("{member} you're sending messages too fast!").format(member=member.mention),
@@ -1686,7 +1500,7 @@ class API:
         return new_list
 
     def _automod_clean_cache(
-        self, guild: discord.Guild, channel: discord.TextChannel, member: discord.Member
+            self, guild: discord.Guild, channel: discord.TextChannel, member: discord.Member
     ):
         """
         We quickly end up with a dict filled with empty values, we gotta clean that.
@@ -1698,7 +1512,7 @@ class API:
                 del self.automod[guild.id]
 
     async def automod_check_for_autowarn(
-        self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
+            self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
     ):
         """
         Iterate through member's modlog, looking for possible automatic warns.
@@ -1724,7 +1538,7 @@ class API:
             )
 
     async def _automod_check_for_autowarn(
-        self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
+            self, guild: discord.Guild, member: discord.Member, author: discord.Member, level: int
     ):
         """
         Prevents having to put this whole function into a try/except block.
@@ -1849,9 +1663,9 @@ class API:
                     # more than 3 errors in our loop, let's shut down the loop
                     log.critical(
                         "The loop for automod warnings encountered a third error. To prevent "
-                        "more damages, the loop will be cancelled. Timed mutes and bans no longer "
-                        "works for now. Reload the cog to start the loop back. If the problem "
-                        "persists, report the error and update the cog.",
+                        "more damages, the loop will be cancelled. Timed bans no longer works for "
+                        "now. Reload the cog to start the loop back. If the problem persists, "
+                        "report the error and update the cog.",
                         exc_info=e,
                     )
                     return

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -347,6 +347,7 @@ class API:
                         "level"     : int,  # between 1 and 5, the warning level
                         "author"    : Union[discord.Member, str],  # the member that warned the user
                         "reason"    : Optional[str],  # the reason of the warn, can be None
+                        "reason"    : Optional[str],  # the reason of the warn, can be None
                         "time"      : datetime.datetime,  # the date when the warn was set
                     },
                     {
@@ -954,7 +955,7 @@ class API:
                 return errors.MissingPermissions(
                     _("I can't take actions on the owner of the guild.")
                 )
-            if level == 2 and not time or time > timedelta(days=28):
+            if level == 2 and (not time or time > timedelta(days=28)):
                 return errors.BadArgument(
                     _("Timeouts require a time to be set up to 28 days maximum.")
                 )

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -666,7 +666,7 @@ class API:
         reason: Optional[str]
             The reason of the warning.
         time: Optional[timedelta]
-            The time before the action ends. Only for timeout and ban.  # TODO: Change text, since it's required by timeouts
+            The time before the action ends. Required for timeouts, optional for bans.
         date: Optional[datetime]
             When the action was taken.
         message_sent: bool
@@ -954,7 +954,10 @@ class API:
                 return errors.MissingPermissions(
                     _("I can't take actions on the owner of the guild.")
                 )
-            # TODO: We probably need to ensure here, that time is present for timeouts
+            if level == 2 and not time or time > timedelta(days=28):
+                return errors.BadArgument(
+                    _("Timeouts require a time to be set up to 28 days maximum.")
+                )
             if member == guild.me:
                 return errors.SuicidePrevention(
                     _(

--- a/warnsystem/api.py
+++ b/warnsystem/api.py
@@ -922,7 +922,7 @@ class API:
             The bot is trying to take actions on someone but their top role is higher
             than the bot's top role in the guild's hierarchy.
         ~warnsystem.errors.MissingPermissions
-            The bot lacks a permissions to do something. Can be adding role, kicking
+            The bot lacks a permissions to do something. Can be timeouting, kicking
             or banning members.
         discord.errors.NotFound
             When the user ID provided for hackban isn't recognized by Discord.

--- a/warnsystem/automod.py
+++ b/warnsystem/automod.py
@@ -24,13 +24,13 @@ class AutomodMixin(MixinMeta):
     """
 
     async def _ask_for_value(
-            self,
-            ctx: commands.Context,
-            bot_msg: discord.Message,
-            embed: discord.Embed,
-            description: str,
-            need: str = "same_context",
-            optional: bool = False,
+        self,
+        ctx: commands.Context,
+        bot_msg: discord.Message,
+        embed: discord.Embed,
+        description: str,
+        need: str = "same_context",
+        optional: bool = False,
     ):
         embed.description = description
         if optional:
@@ -47,9 +47,7 @@ class AutomodMixin(MixinMeta):
                 time = await TimedeltaConverter().convert(ctx, user_msg.content)
             except commands.BadArgument:
                 await ctx.send(_("Invalid time format."))
-                return await self._ask_for_value(
-                    ctx, bot_msg, embed, description, need, optional
-                )
+                return await self._ask_for_value(ctx, bot_msg, embed, description, need, optional)
             else:
                 return time
         if need == "same_context":
@@ -57,20 +55,18 @@ class AutomodMixin(MixinMeta):
         return pred.result
 
     def _format_embed_for_autowarn(
-            self,
-            embed: discord.Embed,
-            number_of_warns: int,
-            warn_level: int,
-            warn_reason: str,
-            lock_level: int,
-            only_automod: bool,
-            time: timedelta,
-            duration: timedelta,
+        self,
+        embed: discord.Embed,
+        number_of_warns: int,
+        warn_level: int,
+        warn_reason: str,
+        lock_level: int,
+        only_automod: bool,
+        time: timedelta,
+        duration: timedelta,
     ) -> discord.Embed:
         time_str = _("Not set.") if not time else self.api._format_timedelta(time)
-        duration_str = (
-            _("Not set.") if not duration else self.api._format_timedelta(duration)
-        )
+        duration_str = _("Not set.") if not duration else self.api._format_timedelta(duration)
         embed.description = _("Number of warnings until action: {num}\n").format(
             num=number_of_warns
         )
@@ -92,15 +88,11 @@ class AutomodMixin(MixinMeta):
                 "bot will set a level {level} warning on him{duration} for the reason: {reason}"
             ).format(
                 number=number_of_warns,
-                level_lock=(
-                    _(" level {level}").format(level=lock_level) if lock_level else ""
-                ),
+                level_lock=(_(" level {level}").format(level=lock_level) if lock_level else ""),
                 from_bot=_(" from the automod") if only_automod else "",
                 within_time=_(" within {time}").format(time=time_str) if time else "",
                 level=warn_level,
-                duration=(
-                    _(" during {time}").format(time=duration_str) if duration else ""
-                ),
+                duration=(_(" during {time}").format(time=duration_str) if duration else ""),
                 reason=warn_reason,
             ),
             inline=False,
@@ -155,14 +147,14 @@ class AutomodMixin(MixinMeta):
 
     @automod_regex.command(name="add")
     async def automod_regex_add(
-            self,
-            ctx: commands.Context,
-            name: str,
-            regex: ValidRegex,
-            level: int,
-            time: Optional[TimedeltaConverter],
-            *,
-            reason: str,
+        self,
+        ctx: commands.Context,
+        name: str,
+        regex: ValidRegex,
+        level: int,
+        time: Optional[TimedeltaConverter],
+        *,
+        reason: str,
     ):
         """
         Create a new Regex trigger for a warning.
@@ -215,15 +207,14 @@ class AutomodMixin(MixinMeta):
             await ctx.send(_("Nothing registered."))
             return
         for name, value in automod_regex.items():
-            text += f"+ {name}\nLevel {value['level']} warning. Reason: {value['reason'][:40]}...\n\n"
+            text += (
+                f"+ {name}\nLevel {value['level']} warning. Reason: {value['reason'][:40]}...\n\n"
+            )
         messages = []
-        pages = list(
-            pagify(text, delims=["\n\n", "\n"], priority=True, page_length=1900)
-        )
+        pages = list(pagify(text, delims=["\n\n", "\n"], priority=True, page_length=1900))
         for i, page in enumerate(pages):
             messages.append(
-                _("Page {i}/{total}").format(i=i + 1, total=len(pages))
-                + box(page, "diff")
+                _("Page {i}/{total}").format(i=i + 1, total=len(pages)) + box(page, "diff")
             )
         await menus.menu(ctx, pages=messages, controls=menus.DEFAULT_CONTROLS)
 
@@ -247,9 +238,7 @@ class AutomodMixin(MixinMeta):
         )
         embed.add_field(
             name=_("Warning"),
-            value=_(
-                "**Level:** {level}\n**Reason:** {reason}\n**Duration:** {time}"
-            ).format(
+            value=_("**Level:** {level}\n**Reason:** {reason}\n**Duration:** {time}").format(
                 level=automod_regex["level"],
                 reason=automod_regex["reason"],
                 time=(
@@ -503,9 +492,9 @@ set them a level 3 warning with the given reason.
             return
         text = ""
         for index, data in enumerate(autowarns):
-            text += _(
-                "{index}. level {level} warn (need {number} warns to trigger)\n"
-            ).format(index=index, level=data["warn"]["level"], number=data["number"])
+            text += _("{index}. level {level} warn (need {number} warns to trigger)\n").format(
+                index=index, level=data["warn"]["level"], number=data["number"]
+            )
         text = list(pagify(text, page_length=1900))
         pages = []
         for i, page in enumerate(text):
@@ -535,9 +524,7 @@ set them a level 3 warning with the given reason.
             except IndexError:
                 await ctx.send(_("There isn't such automated warn."))
                 return
-        embed = discord.Embed(
-            title=_("Settings of auto warn {index}").format(index=index)
-        )
+        embed = discord.Embed(title=_("Settings of auto warn {index}").format(index=index))
         duration = autowarn["warn"]["duration"]
         embed = self._format_embed_for_autowarn(
             embed,
@@ -605,7 +592,7 @@ you shouldn't need further setup.
 
     @automod_antispam.command(name="threshold")
     async def automod_antispam_threshold(
-            self, ctx: commands.Context, max_messages: int, delay: int
+        self, ctx: commands.Context, max_messages: int, delay: int
     ):
         """
         Defines the spam threshold.
@@ -659,12 +646,12 @@ disable this and immediately take actions by setting a delay of 0. Default is 60
 
     @automod_antispam.command(name="warn")
     async def automod_antispam_warn(
-            self,
-            ctx: commands.Context,
-            level: int,
-            duration: Optional[TimedeltaConverter],
-            *,
-            reason: str,
+        self,
+        ctx: commands.Context,
+        level: int,
+        duration: Optional[TimedeltaConverter],
+        *,
+        reason: str,
     ):
         """
         Define the warn taken when the antispam is triggered.
@@ -722,23 +709,17 @@ disable this and immediately take actions by setting a delay of 0. Default is 60
         async with self.data.guild(guild).automod.antispam.whitelist() as whitelist:
             for word in words:
                 if word in whitelist:
-                    await ctx.send(
-                        _("`{word}` is already in the whitelist.").format(word=word)
-                    )
+                    await ctx.send(_("`{word}` is already in the whitelist.").format(word=word))
                     return
             whitelist.extend(words)
         await self.cache.update_automod_antispam()
         if len(words) == 1:
             await ctx.send(_("Added one word to the whitelist."))
         else:
-            await ctx.send(
-                _("Added {num} words to the whitelist.").format(num=len(words))
-            )
+            await ctx.send(_("Added {num} words to the whitelist.").format(num=len(words)))
 
     @automod_antispam_whitelist.command(name="delete", aliases=["del", "remove"])
-    async def automod_antispam_whitelist_delete(
-            self, ctx: commands.Context, *words: str
-    ):
+    async def automod_antispam_whitelist_delete(self, ctx: commands.Context, *words: str):
         """
         Remove multiple words for the whitelist.
 
@@ -751,18 +732,14 @@ disable this and immediately take actions by setting a delay of 0. Default is 60
         async with self.data.guild(guild).automod.antispam.whitelist() as whitelist:
             for word in words:
                 if word not in whitelist:
-                    await ctx.send(
-                        _("`{word}` isn't in the whitelist.").format(word=word)
-                    )
+                    await ctx.send(_("`{word}` isn't in the whitelist.").format(word=word))
                     return
             whitelist = [x for x in whitelist if x not in words]
         await self.cache.update_automod_antispam()
         if len(words) == 1:
             await ctx.send(_("Removed one word from the whitelist."))
         else:
-            await ctx.send(
-                _("Removed {num} words from the whitelist.").format(num=len(words))
-            )
+            await ctx.send(_("Removed {num} words from the whitelist.").format(num=len(words)))
 
     @automod_antispam_whitelist.command(name="list")
     async def automod_antispam_whitelist_list(self, ctx: commands.Context):

--- a/warnsystem/automod.py
+++ b/warnsystem/automod.py
@@ -24,13 +24,13 @@ class AutomodMixin(MixinMeta):
     """
 
     async def _ask_for_value(
-        self,
-        ctx: commands.Context,
-        bot_msg: discord.Message,
-        embed: discord.Embed,
-        description: str,
-        need: str = "same_context",
-        optional: bool = False,
+            self,
+            ctx: commands.Context,
+            bot_msg: discord.Message,
+            embed: discord.Embed,
+            description: str,
+            need: str = "same_context",
+            optional: bool = False,
     ):
         embed.description = description
         if optional:
@@ -47,7 +47,9 @@ class AutomodMixin(MixinMeta):
                 time = await TimedeltaConverter().convert(ctx, user_msg.content)
             except commands.BadArgument:
                 await ctx.send(_("Invalid time format."))
-                return await self._ask_for_value(ctx, bot_msg, embed, description, need, optional)
+                return await self._ask_for_value(
+                    ctx, bot_msg, embed, description, need, optional
+                )
             else:
                 return time
         if need == "same_context":
@@ -55,18 +57,20 @@ class AutomodMixin(MixinMeta):
         return pred.result
 
     def _format_embed_for_autowarn(
-        self,
-        embed: discord.Embed,
-        number_of_warns: int,
-        warn_level: int,
-        warn_reason: str,
-        lock_level: int,
-        only_automod: bool,
-        time: timedelta,
-        duration: timedelta,
+            self,
+            embed: discord.Embed,
+            number_of_warns: int,
+            warn_level: int,
+            warn_reason: str,
+            lock_level: int,
+            only_automod: bool,
+            time: timedelta,
+            duration: timedelta,
     ) -> discord.Embed:
         time_str = _("Not set.") if not time else self.api._format_timedelta(time)
-        duration_str = _("Not set.") if not duration else self.api._format_timedelta(duration)
+        duration_str = (
+            _("Not set.") if not duration else self.api._format_timedelta(duration)
+        )
         embed.description = _("Number of warnings until action: {num}\n").format(
             num=number_of_warns
         )
@@ -88,11 +92,15 @@ class AutomodMixin(MixinMeta):
                 "bot will set a level {level} warning on him{duration} for the reason: {reason}"
             ).format(
                 number=number_of_warns,
-                level_lock=_(" level {level}").format(level=lock_level) if lock_level else "",
+                level_lock=(
+                    _(" level {level}").format(level=lock_level) if lock_level else ""
+                ),
                 from_bot=_(" from the automod") if only_automod else "",
                 within_time=_(" within {time}").format(time=time_str) if time else "",
                 level=warn_level,
-                duration=_(" during {time}").format(time=duration_str) if duration else "",
+                duration=(
+                    _(" during {time}").format(time=duration_str) if duration else ""
+                ),
                 reason=warn_reason,
             ),
             inline=False,
@@ -147,14 +155,14 @@ class AutomodMixin(MixinMeta):
 
     @automod_regex.command(name="add")
     async def automod_regex_add(
-        self,
-        ctx: commands.Context,
-        name: str,
-        regex: ValidRegex,
-        level: int,
-        time: Optional[TimedeltaConverter],
-        *,
-        reason: str,
+            self,
+            ctx: commands.Context,
+            name: str,
+            regex: ValidRegex,
+            level: int,
+            time: Optional[TimedeltaConverter],
+            *,
+            reason: str,
     ):
         """
         Create a new Regex trigger for a warning.
@@ -207,14 +215,15 @@ class AutomodMixin(MixinMeta):
             await ctx.send(_("Nothing registered."))
             return
         for name, value in automod_regex.items():
-            text += (
-                f"+ {name}\nLevel {value['level']} warning. Reason: {value['reason'][:40]}...\n\n"
-            )
+            text += f"+ {name}\nLevel {value['level']} warning. Reason: {value['reason'][:40]}...\n\n"
         messages = []
-        pages = list(pagify(text, delims=["\n\n", "\n"], priority=True, page_length=1900))
+        pages = list(
+            pagify(text, delims=["\n\n", "\n"], priority=True, page_length=1900)
+        )
         for i, page in enumerate(pages):
             messages.append(
-                _("Page {i}/{total}").format(i=i + 1, total=len(pages)) + box(page, "diff")
+                _("Page {i}/{total}").format(i=i + 1, total=len(pages))
+                + box(page, "diff")
             )
         await menus.menu(ctx, pages=messages, controls=menus.DEFAULT_CONTROLS)
 
@@ -232,16 +241,22 @@ class AutomodMixin(MixinMeta):
         embed = discord.Embed(title=_("Regex trigger: {name}").format(name=name))
         embed.description = _("Regex trigger details.")
         embed.add_field(
-            name=_("Regular expression"), value=box(automod_regex["regex"].pattern), inline=False
+            name=_("Regular expression"),
+            value=box(automod_regex["regex"].pattern),
+            inline=False,
         )
         embed.add_field(
             name=_("Warning"),
-            value=_("**Level:** {level}\n**Reason:** {reason}\n**Duration:** {time}").format(
+            value=_(
+                "**Level:** {level}\n**Reason:** {reason}\n**Duration:** {time}"
+            ).format(
                 level=automod_regex["level"],
                 reason=automod_regex["reason"],
-                time=self.api._format_timedelta(automod_regex["time"])
-                if automod_regex["time"]
-                else _("Not set."),
+                time=(
+                    self.api._format_timedelta(automod_regex["time"])
+                    if automod_regex["time"]
+                    else _("Not set.")
+                ),
             ),
             inline=False,
         )
@@ -323,7 +338,11 @@ set them a level 3 warning with the given reason.
                 else:
                     await ctx.send(_("Level must be between 1 and 5."))
             warn_reason = await self._ask_for_value(
-                ctx, msg, embed, _("What's the reason of the automod's warning?"), optional=True
+                ctx,
+                msg,
+                embed,
+                _("What's the reason of the automod's warning?"),
+                optional=True,
             )
             time: timedelta = await self._ask_for_value(
                 ctx,
@@ -334,7 +353,7 @@ set them a level 3 warning with the given reason.
                     "For example, you can make it trigger if a member got 3 warnings"
                     " __within a day__\nOmitting this value will make the automod look across the "
                     "entire member's modlog without time limit.\n\n"
-                    "Format is the same as temp mutes/bans: `30m` = 30 minutes, `2h` = 2 hours, "
+                    "Format is the same as timeouts/temp bans: `30m` = 30 minutes, `2h` = 2 hours, "
                     "`4d` = 4 days..."
                 ),
                 need="time",
@@ -347,13 +366,13 @@ set them a level 3 warning with the given reason.
                     msg,
                     embed,
                     _(
-                        "Level 2 and 5 warnings can be temporary (unmute or unban "
+                        "Level 2 have to be and Level 5 warnings can be temporary (unban "
                         "after some time). For how long should the the member stay punished?\n"
-                        "Skip this value to make the mute/ban unlimited.\n"
+                        "Skip this value for bans to make it unlimited.\n"
                         "Time format is the same as the previous question."
                     ),
                     need="time",
-                    optional=True,
+                    optional=warn_level == 5,
                 )
             while True:
                 lock_level = await self._ask_for_value(
@@ -484,9 +503,9 @@ set them a level 3 warning with the given reason.
             return
         text = ""
         for index, data in enumerate(autowarns):
-            text += _("{index}. level {level} warn (need {number} warns to trigger)\n").format(
-                index=index, level=data["warn"]["level"], number=data["number"]
-            )
+            text += _(
+                "{index}. level {level} warn (need {number} warns to trigger)\n"
+            ).format(index=index, level=data["warn"]["level"], number=data["number"])
         text = list(pagify(text, page_length=1900))
         pages = []
         for i, page in enumerate(text):
@@ -516,7 +535,9 @@ set them a level 3 warning with the given reason.
             except IndexError:
                 await ctx.send(_("There isn't such automated warn."))
                 return
-        embed = discord.Embed(title=_("Settings of auto warn {index}").format(index=index))
+        embed = discord.Embed(
+            title=_("Settings of auto warn {index}").format(index=index)
+        )
         duration = autowarn["warn"]["duration"]
         embed = self._format_embed_for_autowarn(
             embed,
@@ -584,7 +605,7 @@ you shouldn't need further setup.
 
     @automod_antispam.command(name="threshold")
     async def automod_antispam_threshold(
-        self, ctx: commands.Context, max_messages: int, delay: int
+            self, ctx: commands.Context, max_messages: int, delay: int
     ):
         """
         Defines the spam threshold.
@@ -638,12 +659,12 @@ disable this and immediately take actions by setting a delay of 0. Default is 60
 
     @automod_antispam.command(name="warn")
     async def automod_antispam_warn(
-        self,
-        ctx: commands.Context,
-        level: int,
-        duration: Optional[TimedeltaConverter],
-        *,
-        reason: str,
+            self,
+            ctx: commands.Context,
+            level: int,
+            duration: Optional[TimedeltaConverter],
+            *,
+            reason: str,
     ):
         """
         Define the warn taken when the antispam is triggered.
@@ -652,7 +673,7 @@ disable this and immediately take actions by setting a delay of 0. Default is 60
         Examples: `[p]automod antispam warn 1 Spamming` `[p]automod antispam warn 2 30m Spamming`
 
         You can use the `[p]automod warn` command to configure an automatic warning after multiple\
-automod infractions, like a mute after 3 warns.
+        automod infractions, like a timeout after 3 warns.
         """
         guild = ctx.guild
         await self.data.guild(guild).automod.antispam.warn.set(
@@ -670,11 +691,13 @@ automod infractions, like a mute after 3 warns.
             ).format(
                 level=level,
                 reason=reason,
-                duration=_("that will last for {time} ").format(
-                    time=self.api._format_timedelta(duration)
-                )
-                if duration
-                else "",
+                duration=(
+                    _("that will last for {time} ").format(
+                        time=self.api._format_timedelta(duration)
+                    )
+                    if duration
+                    else ""
+                ),
             )
         )
 
@@ -699,17 +722,23 @@ automod infractions, like a mute after 3 warns.
         async with self.data.guild(guild).automod.antispam.whitelist() as whitelist:
             for word in words:
                 if word in whitelist:
-                    await ctx.send(_("`{word}` is already in the whitelist.").format(word=word))
+                    await ctx.send(
+                        _("`{word}` is already in the whitelist.").format(word=word)
+                    )
                     return
             whitelist.extend(words)
         await self.cache.update_automod_antispam()
         if len(words) == 1:
             await ctx.send(_("Added one word to the whitelist."))
         else:
-            await ctx.send(_("Added {num} words to the whitelist.").format(num=len(words)))
+            await ctx.send(
+                _("Added {num} words to the whitelist.").format(num=len(words))
+            )
 
     @automod_antispam_whitelist.command(name="delete", aliases=["del", "remove"])
-    async def automod_antispam_whitelist_delete(self, ctx: commands.Context, *words: str):
+    async def automod_antispam_whitelist_delete(
+            self, ctx: commands.Context, *words: str
+    ):
         """
         Remove multiple words for the whitelist.
 
@@ -722,14 +751,18 @@ automod infractions, like a mute after 3 warns.
         async with self.data.guild(guild).automod.antispam.whitelist() as whitelist:
             for word in words:
                 if word not in whitelist:
-                    await ctx.send(_("`{word}` isn't in the whitelist.").format(word=word))
+                    await ctx.send(
+                        _("`{word}` isn't in the whitelist.").format(word=word)
+                    )
                     return
             whitelist = [x for x in whitelist if x not in words]
         await self.cache.update_automod_antispam()
         if len(words) == 1:
             await ctx.send(_("Removed one word from the whitelist."))
         else:
-            await ctx.send(_("Removed {num} words from the whitelist.").format(num=len(words)))
+            await ctx.send(
+                _("Removed {num} words from the whitelist.").format(num=len(words))
+            )
 
     @automod_antispam_whitelist.command(name="list")
     async def automod_antispam_whitelist_list(self, ctx: commands.Context):
@@ -800,11 +833,13 @@ automod infractions, like a mute after 3 warns.
         reason = antispam_settings["warn"]["reason"]
         if level == 2 or level == 5:
             time = _("Time: {time}\n").format(
-                time=self.api._format_timedelta(
-                    timedelta(seconds=antispam_settings["warn"]["time"])
+                time=(
+                    self.api._format_timedelta(
+                        timedelta(seconds=antispam_settings["warn"]["time"])
+                    )
+                    if antispam_settings["warn"]["time"]
+                    else _("Unlimited.")
                 )
-                if antispam_settings["warn"]["time"]
-                else _("Unlimited.")
             )
         else:
             time = ""

--- a/warnsystem/cache.py
+++ b/warnsystem/cache.py
@@ -45,9 +45,7 @@ class MemoryCache:
         """
         config_data = await self.data.all_guilds()
         guild_temp_actions_cached = len(self.temp_actions)
-        guild_temp_actions = len(
-            [x for x in config_data.values() if x["temporary_warns"]]
-        )
+        guild_temp_actions = len([x for x in config_data.values() if x["temporary_warns"]])
         temp_actions_cached = sum(len(x) for x in self.temp_actions.values())
         temp_actions = sum((len(x["temporary_warns"]) for x in config_data.values()))
         text = (
@@ -58,9 +56,7 @@ class MemoryCache:
         log.info(text)
         return text
 
-    async def get_temp_action(
-            self, guild: discord.Guild, member: Optional[discord.Member] = None
-    ):
+    async def get_temp_action(self, guild: discord.Guild, member: Optional[discord.Member] = None):
         guild_temp_actions = self.temp_actions.get(guild.id, {})
         if not guild_temp_actions:
             guild_temp_actions = await self.data.guild(guild).temporary_warns.all()
@@ -70,9 +66,7 @@ class MemoryCache:
             return guild_temp_actions
         return guild_temp_actions.get(member.id)
 
-    async def add_temp_action(
-            self, guild: discord.Guild, member: discord.Member, data: dict
-    ):
+    async def add_temp_action(self, guild: discord.Guild, member: discord.Member, data: dict):
         await self.data.guild(guild).temporary_warns.set_raw(member.id, value=data)
         try:
             guild_temp_actions = self.temp_actions[guild.id]
@@ -135,13 +129,13 @@ class MemoryCache:
         return automod_regex
 
     async def add_automod_regex(
-            self,
-            guild: discord.Guild,
-            name: str,
-            regex: re.Pattern,
-            level: int,
-            time: int,
-            reason: str,
+        self,
+        guild: discord.Guild,
+        name: str,
+        regex: re.Pattern,
+        level: int,
+        time: int,
+        reason: str,
     ):
         data = {"regex": regex.pattern, "level": level, "time": time, "reason": reason}
         await self.data.guild(guild).automod.regex.set_raw(name, value=data)

--- a/warnsystem/components.py
+++ b/warnsystem/components.py
@@ -82,14 +82,14 @@ def pretty_date(time: datetime):
 
 
 async def prompt_yes_or_no(
-    bot: "Red",
-    interaction: discord.Interaction,
-    content: Optional[str] = None,
-    *,
-    embed: Optional[discord.Embed] = None,
-    timeout: int = 30,
-    clear_after: bool = True,
-    negative_response: bool = True,
+        bot: "Red",
+        interaction: discord.Interaction,
+        content: Optional[str] = None,
+        *,
+        embed: Optional[discord.Embed] = None,
+        timeout: int = 30,
+        clear_after: bool = True,
+        negative_response: bool = True,
 ) -> bool:
     """
     Sends a message and waits for used confirmation, using buttons.
@@ -134,7 +134,9 @@ async def prompt_yes_or_no(
         return inter.user.id == interaction.user.id
 
     try:
-        interaction = await bot.wait_for("interaction", check=check_same_user, timeout=timeout)
+        interaction = await bot.wait_for(
+            "interaction", check=check_same_user, timeout=timeout
+        )
     except AsyncTimeoutError:
         await interaction.response.edit_message(content=_("Request timed out."))
         return False
@@ -143,7 +145,9 @@ async def prompt_yes_or_no(
         if custom_id == f"yes-{interaction.message.id}":
             return True
         if negative_response:
-            await interaction.response.edit_message(content=_("Cancelled."), view=None, embed=None)
+            await interaction.response.edit_message(
+                content=_("Cancelled."), view=None, embed=None
+            )
         return False
     finally:
         if clear_after:
@@ -166,14 +170,14 @@ class WarningEditionModal(Modal, title="Warning reason edition"):
 
 class WarningEditionView(View):
     def __init__(
-        self,
-        bot: "Red",
-        list: WarningsSelector,
-        *,
-        user: Union[discord.Member, UnavailableMember],
-        case: dict,
-        case_index: int,
-        disabled: bool = False,
+            self,
+            bot: "Red",
+            list: WarningsSelector,
+            *,
+            user: Union[discord.Member, UnavailableMember],
+            case: dict,
+            case_index: int,
+            disabled: bool = False,
     ):
         super().__init__()
         self.bot = bot
@@ -187,7 +191,9 @@ class WarningEditionView(View):
             self.edit_button.disabled = True
             self.delete_button.disabled = True
 
-    @discord.ui.button(style=discord.ButtonStyle.secondary, label=_("Edit reason"), emoji="✏")
+    @discord.ui.button(
+        style=discord.ButtonStyle.secondary, label=_("Edit reason"), emoji="✏"
+    )
     async def edit_button(self, interaction: discord.Interaction, button: Button):
         modal = WarningEditionModal()
         await interaction.response.send_modal(modal)
@@ -195,17 +201,28 @@ class WarningEditionView(View):
             pass  # timed out
         interaction = modal.interaction
         embed = discord.Embed()
-        new_reason = await self.api.format_reason(interaction.guild, modal.new_reason.value)
-        embed.description = _("Case #{number} edition.").format(number=self.case_index + 1)
+        new_reason = await self.api.format_reason(
+            interaction.guild, modal.new_reason.value
+        )
+        embed.description = _("Case #{number} edition.").format(
+            number=self.case_index + 1
+        )
         embed.add_field(name=_("Old reason"), value=self.case["reason"], inline=False)
         embed.add_field(name=_("New reason"), value=new_reason, inline=False)
         embed.set_footer(text=_("Click on ✅ to confirm the changes."))
-        response = await prompt_yes_or_no(self.bot, interaction, embed=embed, clear_after=False)
+        response = await prompt_yes_or_no(
+            self.bot, interaction, embed=embed, clear_after=False
+        )
         if response is False:
             return
-        await self.api.edit_case(interaction.guild, self.user, self.case_index + 1, new_reason)
+        await self.api.edit_case(
+            interaction.guild, self.user, self.case_index + 1, new_reason
+        )
         await interaction.followup.edit_message(
-            "@original", content=_("The reason was successfully edited!\n"), embed=None, view=None
+            "@original",
+            content=_("The reason was successfully edited!\n"),
+            embed=None,
+            view=None,
         )
 
     @discord.ui.button(
@@ -216,32 +233,24 @@ class WarningEditionView(View):
     async def delete_button(self, interaction: discord.Interaction, button: Button):
         guild = interaction.guild
         embed = discord.Embed()
-        can_unmute = False
-        add_roles = False
-        if self.case["level"] == 2:
-            mute_role = guild.get_role(await self.ws.cache.get_mute_role(guild))
-            member = guild.get_member(self.user)
-            if member:
-                if mute_role and mute_role in member.roles:
-                    can_unmute = True
-                add_roles = await self.ws.data.guild(guild).remove_roles()
         description = _(
             "Case #{number} deletion.\n**Click on the button to confirm your action.**"
         ).format(number=self.case_index + 1)
-        if can_unmute or add_roles:
-            description += _("\nNote: Deleting the case will also do the following:")
-            if can_unmute:
-                description += _("\n- unmute the member")
-            if add_roles:
-                description += _("\n- add all roles back to the member")
         embed.description = description
-        response = await prompt_yes_or_no(self.bot, interaction, embed=embed, clear_after=False)
+        response = await prompt_yes_or_no(
+            self.bot, interaction, embed=embed, clear_after=False
+        )
         if response is False:
             return
-        await self.api.delete_case(guild, self.user, self.case_index + 1)  # does not starting at 0
+        await self.api.delete_case(
+            guild, self.user, self.case_index + 1
+        )  # does not starting at 0
         self.list.deleted_cases.append(self.case_index)
         await interaction.followup.edit_message(
-            "@original", content=_("The case was successfully deleted!"), embed=None, view=None
+            "@original",
+            content=_("The case was successfully deleted!"),
+            embed=None,
+            view=None,
         )
 
 
@@ -255,7 +264,12 @@ class WarningsSource(menus.ListPageSource):
 
 
 class WarningsSelector(Pages[menus.ListPageSource]):
-    def __init__(self, ctx: Context, user: Union[discord.Member, UnavailableMember], warnings: List[dict]):
+    def __init__(
+            self,
+            ctx: Context,
+            user: Union[discord.Member, UnavailableMember],
+            warnings: List[dict],
+    ):
         self.user = user
         self.ws = cast("WarnSystem", ctx.bot.get_cog("WarnSystem"))
         self.api: "API" = self.ws.api
@@ -268,7 +282,7 @@ class WarningsSelector(Pages[menus.ListPageSource]):
         if level == 1:
             return (_("Warning"), "⚠")
         elif level == 2:
-            return (_("Mute"), "🔇")
+            return (_("Timeout"), "🔇")
         elif level == 3:
             return (_("Kick"), "👢")
         elif level == 4:
@@ -295,10 +309,12 @@ class WarningsSelector(Pages[menus.ListPageSource]):
         self.select_warning_menu.options = options
 
     @discord.ui.select(placeholder="Select a warning to view it.")
-    async def select_warning_menu(self, interaction: discord.Interaction, item:discord.ui.Select):
+    async def select_warning_menu(
+            self, interaction: discord.Interaction, item: discord.ui.Select
+    ):
         warning_str = lambda level, plural: {
             1: (_("Warning"), _("Warnings")),
-            2: (_("Mute"), _("Mutes")),
+            2: (_("Timeout"), _("Timeouts")),
             3: (_("Kick"), _("Kicks")),
             4: (_("Softban"), _("Softbans")),
             5: (_("Ban"), _("Bans")),
@@ -307,14 +323,18 @@ class WarningsSelector(Pages[menus.ListPageSource]):
         guild = interaction.guild
         i = int(interaction.data["values"][0])
         if i in self.deleted_cases:
-            await interaction.response.send_message("This case was deleted.", ephemeral=True)
+            await interaction.response.send_message(
+                "This case was deleted.", ephemeral=True
+            )
             return
         case = self.source.entries[i]
         level = case["level"]
         moderator = guild.get_member(case["author"])
         moderator = "ID: " + str(case["author"]) if not moderator else moderator.mention
         time = self.api._get_datetime(case["time"])
-        embed = discord.Embed(description=_("Case #{number} informations").format(number=i + 1))
+        embed = discord.Embed(
+            description=_("Case #{number} informations").format(number=i + 1)
+        )
         embed.set_author(
             name=f"{self.user} | {self.user.id}", icon_url=self.user.display_avatar.url
         )
@@ -338,6 +358,11 @@ class WarningsSelector(Pages[menus.ListPageSource]):
         await interaction.response.send_message(
             embed=embed,
             view=WarningEditionView(
-                self.bot, self, user=self.user, case=case, case_index=i, disabled=not is_mod
+                self.bot,
+                self,
+                user=self.user,
+                case=case,
+                case_index=i,
+                disabled=not is_mod,
             ),
         )

--- a/warnsystem/components.py
+++ b/warnsystem/components.py
@@ -82,14 +82,14 @@ def pretty_date(time: datetime):
 
 
 async def prompt_yes_or_no(
-        bot: "Red",
-        interaction: discord.Interaction,
-        content: Optional[str] = None,
-        *,
-        embed: Optional[discord.Embed] = None,
-        timeout: int = 30,
-        clear_after: bool = True,
-        negative_response: bool = True,
+    bot: "Red",
+    interaction: discord.Interaction,
+    content: Optional[str] = None,
+    *,
+    embed: Optional[discord.Embed] = None,
+    timeout: int = 30,
+    clear_after: bool = True,
+    negative_response: bool = True,
 ) -> bool:
     """
     Sends a message and waits for used confirmation, using buttons.
@@ -134,9 +134,7 @@ async def prompt_yes_or_no(
         return inter.user.id == interaction.user.id
 
     try:
-        interaction = await bot.wait_for(
-            "interaction", check=check_same_user, timeout=timeout
-        )
+        interaction = await bot.wait_for("interaction", check=check_same_user, timeout=timeout)
     except AsyncTimeoutError:
         await interaction.response.edit_message(content=_("Request timed out."))
         return False
@@ -145,9 +143,7 @@ async def prompt_yes_or_no(
         if custom_id == f"yes-{interaction.message.id}":
             return True
         if negative_response:
-            await interaction.response.edit_message(
-                content=_("Cancelled."), view=None, embed=None
-            )
+            await interaction.response.edit_message(content=_("Cancelled."), view=None, embed=None)
         return False
     finally:
         if clear_after:
@@ -170,14 +166,14 @@ class WarningEditionModal(Modal, title="Warning reason edition"):
 
 class WarningEditionView(View):
     def __init__(
-            self,
-            bot: "Red",
-            list: WarningsSelector,
-            *,
-            user: Union[discord.Member, UnavailableMember],
-            case: dict,
-            case_index: int,
-            disabled: bool = False,
+        self,
+        bot: "Red",
+        list: WarningsSelector,
+        *,
+        user: Union[discord.Member, UnavailableMember],
+        case: dict,
+        case_index: int,
+        disabled: bool = False,
     ):
         super().__init__()
         self.bot = bot
@@ -191,9 +187,7 @@ class WarningEditionView(View):
             self.edit_button.disabled = True
             self.delete_button.disabled = True
 
-    @discord.ui.button(
-        style=discord.ButtonStyle.secondary, label=_("Edit reason"), emoji="✏"
-    )
+    @discord.ui.button(style=discord.ButtonStyle.secondary, label=_("Edit reason"), emoji="✏")
     async def edit_button(self, interaction: discord.Interaction, button: Button):
         modal = WarningEditionModal()
         await interaction.response.send_modal(modal)
@@ -201,23 +195,15 @@ class WarningEditionView(View):
             pass  # timed out
         interaction = modal.interaction
         embed = discord.Embed()
-        new_reason = await self.api.format_reason(
-            interaction.guild, modal.new_reason.value
-        )
-        embed.description = _("Case #{number} edition.").format(
-            number=self.case_index + 1
-        )
+        new_reason = await self.api.format_reason(interaction.guild, modal.new_reason.value)
+        embed.description = _("Case #{number} edition.").format(number=self.case_index + 1)
         embed.add_field(name=_("Old reason"), value=self.case["reason"], inline=False)
         embed.add_field(name=_("New reason"), value=new_reason, inline=False)
         embed.set_footer(text=_("Click on ✅ to confirm the changes."))
-        response = await prompt_yes_or_no(
-            self.bot, interaction, embed=embed, clear_after=False
-        )
+        response = await prompt_yes_or_no(self.bot, interaction, embed=embed, clear_after=False)
         if response is False:
             return
-        await self.api.edit_case(
-            interaction.guild, self.user, self.case_index + 1, new_reason
-        )
+        await self.api.edit_case(interaction.guild, self.user, self.case_index + 1, new_reason)
         await interaction.followup.edit_message(
             "@original",
             content=_("The reason was successfully edited!\n"),
@@ -237,14 +223,10 @@ class WarningEditionView(View):
             "Case #{number} deletion.\n**Click on the button to confirm your action.**"
         ).format(number=self.case_index + 1)
         embed.description = description
-        response = await prompt_yes_or_no(
-            self.bot, interaction, embed=embed, clear_after=False
-        )
+        response = await prompt_yes_or_no(self.bot, interaction, embed=embed, clear_after=False)
         if response is False:
             return
-        await self.api.delete_case(
-            guild, self.user, self.case_index + 1
-        )  # does not starting at 0
+        await self.api.delete_case(guild, self.user, self.case_index + 1)  # does not starting at 0
         self.list.deleted_cases.append(self.case_index)
         await interaction.followup.edit_message(
             "@original",
@@ -265,10 +247,10 @@ class WarningsSource(menus.ListPageSource):
 
 class WarningsSelector(Pages[menus.ListPageSource]):
     def __init__(
-            self,
-            ctx: Context,
-            user: Union[discord.Member, UnavailableMember],
-            warnings: List[dict],
+        self,
+        ctx: Context,
+        user: Union[discord.Member, UnavailableMember],
+        warnings: List[dict],
     ):
         self.user = user
         self.ws = cast("WarnSystem", ctx.bot.get_cog("WarnSystem"))
@@ -309,9 +291,7 @@ class WarningsSelector(Pages[menus.ListPageSource]):
         self.select_warning_menu.options = options
 
     @discord.ui.select(placeholder="Select a warning to view it.")
-    async def select_warning_menu(
-            self, interaction: discord.Interaction, item: discord.ui.Select
-    ):
+    async def select_warning_menu(self, interaction: discord.Interaction, item: discord.ui.Select):
         warning_str = lambda level, plural: {
             1: (_("Warning"), _("Warnings")),
             2: (_("Timeout"), _("Timeouts")),
@@ -323,18 +303,14 @@ class WarningsSelector(Pages[menus.ListPageSource]):
         guild = interaction.guild
         i = int(interaction.data["values"][0])
         if i in self.deleted_cases:
-            await interaction.response.send_message(
-                "This case was deleted.", ephemeral=True
-            )
+            await interaction.response.send_message("This case was deleted.", ephemeral=True)
             return
         case = self.source.entries[i]
         level = case["level"]
         moderator = guild.get_member(case["author"])
         moderator = "ID: " + str(case["author"]) if not moderator else moderator.mention
         time = self.api._get_datetime(case["time"])
-        embed = discord.Embed(
-            description=_("Case #{number} informations").format(number=i + 1)
-        )
+        embed = discord.Embed(description=_("Case #{number} informations").format(number=i + 1))
         embed.set_author(
             name=f"{self.user} | {self.user.id}", icon_url=self.user.display_avatar.url
         )

--- a/warnsystem/context_menus.py
+++ b/warnsystem/context_menus.py
@@ -41,7 +41,10 @@ class ReasonEntry(Modal, title="Member warn"):
     )
 
     def __init__(
-        self, og_interaction: discord.Interaction["Red"], level: int, member: discord.Member
+            self,
+            og_interaction: discord.Interaction["Red"],
+            level: int,
+            member: discord.Member,
     ):
         super().__init__()
         self.og_interaction = og_interaction
@@ -57,10 +60,14 @@ class ReasonEntry(Modal, title="Member warn"):
             try:
                 duration = parse_timedelta(self.duration.value)
             except BadArgument:
-                await interaction.response.send_message(_("Invalid duration"), ephemeral=True)
+                await interaction.response.send_message(
+                    _("Invalid duration"), ephemeral=True
+                )
                 return
             if not duration:
-                await interaction.response.send_message(_("Invalid duration"), ephemeral=True)
+                await interaction.response.send_message(
+                    _("Invalid duration"), ephemeral=True
+                )
                 return
         if self.ban_days.value:
             try:
@@ -89,7 +96,9 @@ class ReasonEntry(Modal, title="Member warn"):
 
 
 class WarnView(View):
-    def __init__(self, og_interaction: discord.Interaction["Red"], member: discord.Member):
+    def __init__(
+            self, og_interaction: discord.Interaction["Red"], member: discord.Member
+    ):
         self.og_interaction = og_interaction
         self.member = member
         super().__init__(timeout=30)
@@ -110,27 +119,39 @@ class WarnView(View):
         await interaction.response.send_modal(modal)
 
     @button(label="Warn", style=discord.ButtonStyle.secondary, emoji="\N{WARNING SIGN}")
-    async def warn_1(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
+    async def warn_1(
+            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
+    ):
         await self.warn(interaction, 1)
 
     @button(
-        label="Mute",
+        label="Timeout",
         style=discord.ButtonStyle.secondary,
         emoji="\N{SPEAKER WITH CANCELLATION STROKE}",
     )
-    async def warn_2(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
+    async def warn_2(
+            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
+    ):
         await self.warn(interaction, 2)
 
     @button(label="Kick", style=discord.ButtonStyle.primary, emoji="\N{WOMANS BOOTS}")
-    async def warn_3(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
+    async def warn_3(
+            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
+    ):
         await self.warn(interaction, 3)
 
-    @button(label="Softban", style=discord.ButtonStyle.primary, emoji="\N{WOMANS BOOTS}")
-    async def warn_4(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
+    @button(
+        label="Softban", style=discord.ButtonStyle.primary, emoji="\N{WOMANS BOOTS}"
+    )
+    async def warn_4(
+            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
+    ):
         await self.warn(interaction, 4)
 
     @button(label="Ban", style=discord.ButtonStyle.danger, emoji="\N{HAMMER}")
-    async def warn_5(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
+    async def warn_5(
+            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
+    ):
         await self.warn(interaction, 5)
 
 
@@ -143,8 +164,8 @@ async def context_warn(interaction: discord.Interaction["Red"], member: discord.
         )
         return
     if (
-        not interaction.user.guild_permissions.administrator
-        and not await interaction.client.is_mod(interaction.user)
+            not interaction.user.guild_permissions.administrator
+            and not await interaction.client.is_mod(interaction.user)
     ):
         await interaction.response.send_message(
             _("You are not allowed to do this"), ephemeral=True

--- a/warnsystem/context_menus.py
+++ b/warnsystem/context_menus.py
@@ -41,10 +41,10 @@ class ReasonEntry(Modal, title="Member warn"):
     )
 
     def __init__(
-            self,
-            og_interaction: discord.Interaction["Red"],
-            level: int,
-            member: discord.Member,
+        self,
+        og_interaction: discord.Interaction["Red"],
+        level: int,
+        member: discord.Member,
     ):
         super().__init__()
         self.og_interaction = og_interaction
@@ -60,14 +60,10 @@ class ReasonEntry(Modal, title="Member warn"):
             try:
                 duration = parse_timedelta(self.duration.value)
             except BadArgument:
-                await interaction.response.send_message(
-                    _("Invalid duration"), ephemeral=True
-                )
+                await interaction.response.send_message(_("Invalid duration"), ephemeral=True)
                 return
             if not duration:
-                await interaction.response.send_message(
-                    _("Invalid duration"), ephemeral=True
-                )
+                await interaction.response.send_message(_("Invalid duration"), ephemeral=True)
                 return
         if self.ban_days.value:
             try:
@@ -96,9 +92,7 @@ class ReasonEntry(Modal, title="Member warn"):
 
 
 class WarnView(View):
-    def __init__(
-            self, og_interaction: discord.Interaction["Red"], member: discord.Member
-    ):
+    def __init__(self, og_interaction: discord.Interaction["Red"], member: discord.Member):
         self.og_interaction = og_interaction
         self.member = member
         super().__init__(timeout=30)
@@ -119,9 +113,7 @@ class WarnView(View):
         await interaction.response.send_modal(modal)
 
     @button(label="Warn", style=discord.ButtonStyle.secondary, emoji="\N{WARNING SIGN}")
-    async def warn_1(
-            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
-    ):
+    async def warn_1(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
         await self.warn(interaction, 1)
 
     @button(
@@ -129,29 +121,19 @@ class WarnView(View):
         style=discord.ButtonStyle.secondary,
         emoji="\N{SPEAKER WITH CANCELLATION STROKE}",
     )
-    async def warn_2(
-            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
-    ):
+    async def warn_2(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
         await self.warn(interaction, 2)
 
     @button(label="Kick", style=discord.ButtonStyle.primary, emoji="\N{WOMANS BOOTS}")
-    async def warn_3(
-            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
-    ):
+    async def warn_3(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
         await self.warn(interaction, 3)
 
-    @button(
-        label="Softban", style=discord.ButtonStyle.primary, emoji="\N{WOMANS BOOTS}"
-    )
-    async def warn_4(
-            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
-    ):
+    @button(label="Softban", style=discord.ButtonStyle.primary, emoji="\N{WOMANS BOOTS}")
+    async def warn_4(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
         await self.warn(interaction, 4)
 
     @button(label="Ban", style=discord.ButtonStyle.danger, emoji="\N{HAMMER}")
-    async def warn_5(
-            self, interaction: discord.Interaction["Red"], button: discord.ui.Button
-    ):
+    async def warn_5(self, interaction: discord.Interaction["Red"], button: discord.ui.Button):
         await self.warn(interaction, 5)
 
 
@@ -164,8 +146,8 @@ async def context_warn(interaction: discord.Interaction["Red"], member: discord.
         )
         return
     if (
-            not interaction.user.guild_permissions.administrator
-            and not await interaction.client.is_mod(interaction.user)
+        not interaction.user.guild_permissions.administrator
+        and not await interaction.client.is_mod(interaction.user)
     ):
         await interaction.response.send_message(
             _("You are not allowed to do this"), ephemeral=True

--- a/warnsystem/converters.py
+++ b/warnsystem/converters.py
@@ -130,9 +130,7 @@ class AdvancedMemberSelect:
         parser.add_argument("--has-all-roles", dest="has_all_roles", nargs="+")
         parser.add_argument("--has-none-roles", dest="has_none_roles", nargs="+")
         parser.add_argument("--has-no-roles", dest="has_no_roles", action="store_true")
-        parser.add_argument(
-            "--has-exactly-nroles", dest="has_exactly_nroles", nargs=1, type=int
-        )
+        parser.add_argument("--has-exactly-nroles", dest="has_exactly_nroles", nargs=1, type=int)
         parser.add_argument(
             "--has-more-than-nroles", dest="has_more_than_nroles", nargs=1, type=int
         )
@@ -183,13 +181,9 @@ class AdvancedMemberSelect:
                 self.non_lurker_members(members), " ".join(args.joined_after), "after"
             )
         if args.last_njoins:
-            members = self._last_njoins(
-                self.non_lurker_members(members), args.last_njoins
-            )
+            members = self._last_njoins(self.non_lurker_members(members), args.last_njoins)
         if args.first_njoins:
-            members = self._first_njoins(
-                self.non_lurker_members(members), args.first_njoins
-            )
+            members = self._first_njoins(self.non_lurker_members(members), args.first_njoins)
 
         if args.has_perm:
             members = self._perms(members, [args.has_perm], "perm")
@@ -288,13 +282,11 @@ class AdvancedMemberSelect:
 
     def _last_njoins(self, members: List[discord.Member], number: int):
         try:
-            last_member = sorted(members, key=lambda x: x.joined_at, reverse=True)[
-                number
-            ]
+            last_member = sorted(members, key=lambda x: x.joined_at, reverse=True)[number]
         except IndexError:
             last_member = sorted(members, key=lambda x: x.joined_at, reverse=True)[
                 len(members) - 1
-                ]
+            ]
 
         def member_filter(member: discord.Member):
             if member.joined_at > last_member.joined_at:
@@ -332,19 +324,15 @@ class AdvancedMemberSelect:
                 if getattr(member.guild_permissions, permissions[0]):
                     return True
             elif requires == "any-perm":
-                if set([x[0] for x in member.guild_permissions if x[1]]).intersection(
-                        permissions
-                ):
+                if set([x[0] for x in member.guild_permissions if x[1]]).intersection(permissions):
                     return True
             elif requires == "all-perms":
-                if set(permissions).issubset(
-                        [x[0] for x in member.guild_permissions if x[1]]
-                ):
+                if set(permissions).issubset([x[0] for x in member.guild_permissions if x[1]]):
                     return True
             elif requires == "none-perms":
-                if not set(
-                        [x[0] for x in member.guild_permissions if x[1]]
-                ).intersection(permissions):
+                if not set([x[0] for x in member.guild_permissions if x[1]]).intersection(
+                    permissions
+                ):
                     return True
             return False
 
@@ -359,7 +347,7 @@ class AdvancedMemberSelect:
         return list(filter(member_filter, members))
 
     async def _role(
-            self, members: List[discord.Member], _roles: List[discord.Role], requires: str
+        self, members: List[discord.Member], _roles: List[discord.Role], requires: str
     ):
         if _roles:
             roles: List[discord.Role] = []
@@ -367,8 +355,8 @@ class AdvancedMemberSelect:
                 try:
                     roles.append(await RoleConverter().convert(self.ctx, role))
                 except (
-                        discord.errors.NotFound,
-                        discord.ext.commands.errors.BadArgument,
+                    discord.errors.NotFound,
+                    discord.ext.commands.errors.BadArgument,
                 ):
                     raise BadArgument(
                         _(
@@ -385,9 +373,7 @@ class AdvancedMemberSelect:
                 return True
             elif requires == "has-all-roles" and set(roles).issubset(member.roles):
                 return True
-            elif requires == "has-none-roles" and not set(member.roles).intersection(
-                    roles
-            ):
+            elif requires == "has-none-roles" and not set(member.roles).intersection(roles):
                 return True
             elif requires == "has-no-roles" and len(member.roles) == 1:
                 return True
@@ -457,9 +443,7 @@ class AdvancedMemberSelect:
             self.reason = " ".join(args.reason or "")
             if args.time:
                 try:
-                    self.time = await TimedeltaConverter().convert(
-                        ctx, " ".join(args.time)
-                    )
+                    self.time = await TimedeltaConverter().convert(ctx, " ".join(args.time))
                 except BadArgument as e:
                     raise BadArgument(
                         _(
@@ -494,8 +478,6 @@ class ValidRegex(Converter):
             result = re.compile(argument)
         except Exception as e:
             log.error("Retrigger conversion error")
-            err_msg = _("`{arg}` is not a valid regex pattern. {e}").format(
-                arg=argument, e=e
-            )
+            err_msg = _("`{arg}` is not a valid regex pattern. {e}").format(arg=argument, e=e)
             raise BadArgument(err_msg)
         return result

--- a/warnsystem/converters.py
+++ b/warnsystem/converters.py
@@ -91,7 +91,8 @@ class AdvancedMemberSelect:
 
     def parse_arguments(self, arguments: str):
         parser = NoExitParser(
-            description="Mass member selection in a server for WarnSystem.", add_help=False
+            description="Mass member selection in a server for WarnSystem.",
+            add_help=False,
         )
 
         parser.add_argument(
@@ -129,7 +130,9 @@ class AdvancedMemberSelect:
         parser.add_argument("--has-all-roles", dest="has_all_roles", nargs="+")
         parser.add_argument("--has-none-roles", dest="has_none_roles", nargs="+")
         parser.add_argument("--has-no-roles", dest="has_no_roles", action="store_true")
-        parser.add_argument("--has-exactly-nroles", dest="has_exactly_nroles", nargs=1, type=int)
+        parser.add_argument(
+            "--has-exactly-nroles", dest="has_exactly_nroles", nargs=1, type=int
+        )
         parser.add_argument(
             "--has-more-than-nroles", dest="has_more_than_nroles", nargs=1, type=int
         )
@@ -180,9 +183,13 @@ class AdvancedMemberSelect:
                 self.non_lurker_members(members), " ".join(args.joined_after), "after"
             )
         if args.last_njoins:
-            members = self._last_njoins(self.non_lurker_members(members), args.last_njoins)
+            members = self._last_njoins(
+                self.non_lurker_members(members), args.last_njoins
+            )
         if args.first_njoins:
-            members = self._first_njoins(self.non_lurker_members(members), args.first_njoins)
+            members = self._first_njoins(
+                self.non_lurker_members(members), args.first_njoins
+            )
 
         if args.has_perm:
             members = self._perms(members, [args.has_perm], "perm")
@@ -281,11 +288,13 @@ class AdvancedMemberSelect:
 
     def _last_njoins(self, members: List[discord.Member], number: int):
         try:
-            last_member = sorted(members, key=lambda x: x.joined_at, reverse=True)[number]
+            last_member = sorted(members, key=lambda x: x.joined_at, reverse=True)[
+                number
+            ]
         except IndexError:
             last_member = sorted(members, key=lambda x: x.joined_at, reverse=True)[
                 len(members) - 1
-            ]
+                ]
 
         def member_filter(member: discord.Member):
             if member.joined_at > last_member.joined_at:
@@ -323,15 +332,19 @@ class AdvancedMemberSelect:
                 if getattr(member.guild_permissions, permissions[0]):
                     return True
             elif requires == "any-perm":
-                if set([x[0] for x in member.guild_permissions if x[1]]).intersection(permissions):
+                if set([x[0] for x in member.guild_permissions if x[1]]).intersection(
+                        permissions
+                ):
                     return True
             elif requires == "all-perms":
-                if set(permissions).issubset([x[0] for x in member.guild_permissions if x[1]]):
+                if set(permissions).issubset(
+                        [x[0] for x in member.guild_permissions if x[1]]
+                ):
                     return True
             elif requires == "none-perms":
-                if not set([x[0] for x in member.guild_permissions if x[1]]).intersection(
-                    permissions
-                ):
+                if not set(
+                        [x[0] for x in member.guild_permissions if x[1]]
+                ).intersection(permissions):
                     return True
             return False
 
@@ -346,14 +359,17 @@ class AdvancedMemberSelect:
         return list(filter(member_filter, members))
 
     async def _role(
-        self, members: List[discord.Member], _roles: List[discord.Role], requires: str
+            self, members: List[discord.Member], _roles: List[discord.Role], requires: str
     ):
         if _roles:
             roles: List[discord.Role] = []
             for role in _roles:
                 try:
                     roles.append(await RoleConverter().convert(self.ctx, role))
-                except (discord.errors.NotFound, discord.ext.commands.errors.BadArgument):
+                except (
+                        discord.errors.NotFound,
+                        discord.ext.commands.errors.BadArgument,
+                ):
                     raise BadArgument(
                         _(
                             "Can't convert `{arg}` from `--{state}` into a "
@@ -369,7 +385,9 @@ class AdvancedMemberSelect:
                 return True
             elif requires == "has-all-roles" and set(roles).issubset(member.roles):
                 return True
-            elif requires == "has-none-roles" and not set(member.roles).intersection(roles):
+            elif requires == "has-none-roles" and not set(member.roles).intersection(
+                    roles
+            ):
                 return True
             elif requires == "has-no-roles" and len(member.roles) == 1:
                 return True
@@ -439,7 +457,9 @@ class AdvancedMemberSelect:
             self.reason = " ".join(args.reason or "")
             if args.time:
                 try:
-                    self.time = await TimedeltaConverter().convert(ctx, " ".join(args.time))
+                    self.time = await TimedeltaConverter().convert(
+                        ctx, " ".join(args.time)
+                    )
                 except BadArgument as e:
                     raise BadArgument(
                         _(
@@ -474,6 +494,8 @@ class ValidRegex(Converter):
             result = re.compile(argument)
         except Exception as e:
             log.error("Retrigger conversion error")
-            err_msg = _("`{arg}` is not a valid regex pattern. {e}").format(arg=argument, e=e)
+            err_msg = _("`{arg}` is not a valid regex pattern. {e}").format(
+                arg=argument, e=e
+            )
             raise BadArgument(err_msg)
         return result

--- a/warnsystem/errors.py
+++ b/warnsystem/errors.py
@@ -29,7 +29,6 @@ If you need to prevent and exception, do it like this:
 __all__ = [
     "InvalidLevel",
     "NotFound",
-    "MissingMuteRole",
     "BadArgument",
     "MissingPermissions",
     "MemberTooHigh",
@@ -60,15 +59,6 @@ class NotFound(Exception):
 class UserNotFound(Exception):
     """
     Cannot find the given user for a hackban.
-    """
-
-    pass
-
-
-class MissingMuteRole(Exception):
-    """
-    You requested a mute warn but the mute role doesn't exist. Call
-    :func:`~warnsystem.api.API.maybe_create_role` to fix this.
     """
 
     pass
@@ -126,8 +116,7 @@ class LostPermissions(Exception):
     """
     The bot lost a permission it had.
 
-    This can be the permission to send messages in the modlog channel or use\
-    the mute role.
+    This can be the permission to send messages in the modlog channel.
     """
 
     pass

--- a/warnsystem/locales/messages.pot
+++ b/warnsystem/locales/messages.pot
@@ -2,327 +2,296 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-15 18:41+0100\n"
+"POT-Creation-Date: 2024-04-04 14:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: redgettext 3.3\n"
+"Generated-By: redgettext 3.4.2\n"
 
-#: warnsystem/__init__.py:112 warnsystem/api.py:206
-#: warnsystem/warnsystem.py:56
+#: warnsystem/__init__.py:106 warnsystem/api.py:219
+#: warnsystem/components.py:46
 msgid "year"
 msgstr ""
 
-#: warnsystem/__init__.py:112 warnsystem/api.py:206
-#: warnsystem/warnsystem.py:56
+#: warnsystem/__init__.py:106 warnsystem/api.py:219
+#: warnsystem/components.py:46
 msgid "years"
 msgstr ""
 
-#: warnsystem/__init__.py:113 warnsystem/api.py:207
-#: warnsystem/warnsystem.py:57
+#: warnsystem/__init__.py:107 warnsystem/api.py:220
+#: warnsystem/components.py:47
 msgid "month"
 msgstr ""
 
-#: warnsystem/__init__.py:113 warnsystem/api.py:207
-#: warnsystem/warnsystem.py:57
+#: warnsystem/__init__.py:107 warnsystem/api.py:220
+#: warnsystem/components.py:47
 msgid "months"
 msgstr ""
 
-#: warnsystem/__init__.py:114 warnsystem/api.py:208
-#: warnsystem/warnsystem.py:58
+#: warnsystem/__init__.py:108 warnsystem/api.py:221
+#: warnsystem/components.py:48
 msgid "week"
 msgstr ""
 
-#: warnsystem/__init__.py:114 warnsystem/api.py:208
-#: warnsystem/warnsystem.py:58
+#: warnsystem/__init__.py:108 warnsystem/api.py:221
+#: warnsystem/components.py:48
 msgid "weeks"
 msgstr ""
 
-#: warnsystem/__init__.py:115 warnsystem/api.py:209
-#: warnsystem/warnsystem.py:59
+#: warnsystem/__init__.py:109 warnsystem/api.py:222
+#: warnsystem/components.py:49
 msgid "day"
 msgstr ""
 
-#: warnsystem/__init__.py:115 warnsystem/api.py:209
-#: warnsystem/warnsystem.py:59
+#: warnsystem/__init__.py:109 warnsystem/api.py:222
+#: warnsystem/components.py:49
 msgid "days"
 msgstr ""
 
-#: warnsystem/__init__.py:116 warnsystem/api.py:210
-#: warnsystem/warnsystem.py:60
+#: warnsystem/__init__.py:110 warnsystem/api.py:223
+#: warnsystem/components.py:50
 msgid "hour"
 msgstr ""
 
-#: warnsystem/__init__.py:116 warnsystem/api.py:210
-#: warnsystem/warnsystem.py:60
+#: warnsystem/__init__.py:110 warnsystem/api.py:223
+#: warnsystem/components.py:50
 msgid "hours"
 msgstr ""
 
-#: warnsystem/__init__.py:117 warnsystem/api.py:211
-#: warnsystem/warnsystem.py:61
+#: warnsystem/__init__.py:111 warnsystem/api.py:224
+#: warnsystem/components.py:51
 msgid "minute"
 msgstr ""
 
-#: warnsystem/__init__.py:117 warnsystem/api.py:211
-#: warnsystem/warnsystem.py:61
+#: warnsystem/__init__.py:111 warnsystem/api.py:224
+#: warnsystem/components.py:51
 msgid "minutes"
 msgstr ""
 
-#: warnsystem/__init__.py:118 warnsystem/api.py:212
-#: warnsystem/warnsystem.py:62
+#: warnsystem/__init__.py:112 warnsystem/api.py:225
+#: warnsystem/components.py:52
 msgid "second"
 msgstr ""
 
-#: warnsystem/__init__.py:118 warnsystem/api.py:212
-#: warnsystem/warnsystem.py:62
+#: warnsystem/__init__.py:112 warnsystem/api.py:225
+#: warnsystem/components.py:52
 msgid "seconds"
 msgstr ""
 
-#: warnsystem/__init__.py:120 warnsystem/api.py:221
-#: warnsystem/warnsystem.py:404
+#: warnsystem/__init__.py:114 warnsystem/api.py:234
+#: warnsystem/warnsystem.py:324
 msgid " and "
 msgstr ""
 
-#: warnsystem/api.py:92
+#: warnsystem/api.py:109
 msgid ""
 "The given member cannot be found.\n"
 "If you're trying to hackban, the user ID is not valid."
 msgstr ""
 
-#: warnsystem/api.py:592 warnsystem/api.py:1109
+#: warnsystem/api.py:460 warnsystem/api.py:765 warnsystem/api.py:784
+#: warnsystem/components.py:330
+msgid "Reason"
+msgstr ""
+
+#: warnsystem/api.py:681 warnsystem/api.py:1103
 msgid "warn"
 msgstr ""
 
-#: warnsystem/api.py:592
+#: warnsystem/api.py:681
 msgid "warns"
 msgstr ""
 
-#: warnsystem/api.py:593 warnsystem/api.py:1109 warnsystem/api.py:1198
-msgid "mute"
+#: warnsystem/api.py:682 warnsystem/api.py:1103
+msgid "timeout"
 msgstr ""
 
-#: warnsystem/api.py:593
-msgid "mutes"
+#: warnsystem/api.py:682
+msgid "timeouts"
 msgstr ""
 
-#: warnsystem/api.py:594 warnsystem/api.py:1109
+#: warnsystem/api.py:683 warnsystem/api.py:1103
 msgid "kick"
 msgstr ""
 
-#: warnsystem/api.py:594
+#: warnsystem/api.py:683
 msgid "kicks"
 msgstr ""
 
-#: warnsystem/api.py:595 warnsystem/api.py:1109
+#: warnsystem/api.py:684 warnsystem/api.py:1103
 msgid "softban"
 msgstr ""
 
-#: warnsystem/api.py:595
+#: warnsystem/api.py:684
 msgid "softbans"
 msgstr ""
 
-#: warnsystem/api.py:596 warnsystem/api.py:1109 warnsystem/api.py:1198
+#: warnsystem/api.py:685 warnsystem/api.py:1103 warnsystem/api.py:1192
 msgid "ban"
 msgstr ""
 
-#: warnsystem/api.py:596
+#: warnsystem/api.py:685
 msgid "bans"
 msgstr ""
 
-#: warnsystem/api.py:597 warnsystem/api.py:1110 warnsystem/warnsystem.py:820
+#: warnsystem/api.py:686 warnsystem/api.py:1104 warnsystem/components.py:301
+#: warnsystem/warnsystem.py:744
 msgid "unknown"
 msgstr ""
 
-#: warnsystem/api.py:600
+#: warnsystem/api.py:689
 msgid "No reason was provided."
 msgstr ""
 
-#: warnsystem/api.py:601
+#: warnsystem/api.py:690
 msgid ""
 "\n"
 "Edit this with `[p]warnings {id}`"
 msgstr ""
 
-#: warnsystem/api.py:612
+#: warnsystem/api.py:701
 msgid "{who} now {verb} {total} {warning} ({total_type} {action})"
 msgstr ""
 
-#: warnsystem/api.py:615
+#: warnsystem/api.py:704
 msgid "The member"
 msgstr ""
 
-#: warnsystem/api.py:615
+#: warnsystem/api.py:704
 msgid "You"
 msgstr ""
 
-#: warnsystem/api.py:616
+#: warnsystem/api.py:705
 msgid "has"
 msgstr ""
 
-#: warnsystem/api.py:616
+#: warnsystem/api.py:705
 msgid "have"
 msgstr ""
 
-#: warnsystem/api.py:618
+#: warnsystem/api.py:707
 msgid "warnings"
 msgstr ""
 
-#: warnsystem/api.py:618
+#: warnsystem/api.py:707
 msgid "warning"
 msgstr ""
 
-#: warnsystem/api.py:630 warnsystem/api.py:636
+#: warnsystem/api.py:719 warnsystem/api.py:725
 msgid "*[couldn't create an invite]*"
 msgstr ""
 
-#: warnsystem/api.py:644
+#: warnsystem/api.py:733
 msgid "*[No time given]*"
 msgstr ""
 
-#: warnsystem/api.py:666
+#: warnsystem/api.py:757
 msgid "Level {level} warning ({action})"
 msgstr ""
 
-#: warnsystem/api.py:670
+#: warnsystem/api.py:761
 msgid "Member"
 msgstr ""
 
-#: warnsystem/api.py:671 warnsystem/warnsystem.py:872
+#: warnsystem/api.py:762 warnsystem/components.py:320
 msgid "Moderator"
 msgstr ""
 
-#: warnsystem/api.py:673 warnsystem/api.py:698 warnsystem/warnsystem.py:876
+#: warnsystem/api.py:764 warnsystem/api.py:790 warnsystem/components.py:324
 msgid "Duration"
 msgstr ""
 
-#: warnsystem/api.py:674 warnsystem/api.py:692 warnsystem/warnsystem.py:882
-#: warnsystem/warnsystem.py:940
-msgid "Reason"
-msgstr ""
-
-#: warnsystem/api.py:675 warnsystem/api.py:695
+#: warnsystem/api.py:766 warnsystem/api.py:787
 msgid "Status"
 msgstr ""
 
-#: warnsystem/api.py:682
+#: warnsystem/api.py:774
 msgid ""
 "\n"
 "\n"
 "***The message could not be delivered to the user. They may have DMs disabled, blocked the bot, or may not have a mutual server.***"
 msgstr ""
 
-#: warnsystem/api.py:740 warnsystem/api.py:1087 warnsystem/settings.py:484
-msgid "I can't manage roles, please give me this permission to continue."
-msgstr ""
-
-#: warnsystem/api.py:746
-msgid ""
-"WarnSystem mute role. This role will be assigned to the muted members, feel "
-"free to move it or modify its channel permissions."
-msgstr ""
-
-#: warnsystem/api.py:754
-msgid ""
-"Modifying role's position, keep it under my top role so I can add it to "
-"muted members."
-msgstr ""
-
-#: warnsystem/api.py:766
-msgid ""
-"Setting up WarnSystem mute. All muted members will have this role, feel free"
-" to edit its permissions."
-msgstr ""
-
-#: warnsystem/api.py:773
-msgid ""
-"Cannot edit permissions of the channel {channel} because of a permission "
-"error (probably enforced permission for `Manage channel`)."
-msgstr ""
-
-#: warnsystem/api.py:780 warnsystem/api.py:792
-msgid ""
-"Cannot edit permissions of the channel {channel} because of an unknown "
-"error."
-msgstr ""
-
-#: warnsystem/api.py:956
+#: warnsystem/api.py:940
 msgid ""
 "Cannot take actions on this member, they are above me in the roles "
 "hierarchy. Modify the hierarchy so my top role ({bot_role}) is above "
 "{member_role}."
 msgstr ""
 
-#: warnsystem/api.py:971
+#: warnsystem/api.py:955
 msgid "I can't take actions on the owner of the guild."
 msgstr ""
 
-#: warnsystem/api.py:975
+#: warnsystem/api.py:959
+msgid "Timeouts require a time to be set up to 28 days maximum."
+msgstr ""
+
+#: warnsystem/api.py:963
 msgid ""
 "Why would you warn me? I did nothing wrong :c\n"
 "(use a manual kick/ban instead, warning the bot will cause issues)"
 msgstr ""
 
-#: warnsystem/api.py:1024
+#: warnsystem/api.py:1018
 msgid "Unbanning the softbanned member after cleaning up the messages."
 msgstr ""
 
-#: warnsystem/api.py:1078
+#: warnsystem/api.py:1080
 msgid ""
 "I need the `Send messages` and `Embed links` permissions in {channel} to do "
 "this."
 msgstr ""
 
-#: warnsystem/api.py:1091
-msgid ""
-"The mute role `{mute_role}` was moved above my top role `{my_role}`. Please "
-"move the roles so my top role is above the mute role."
+#: warnsystem/api.py:1088
+msgid "I can't timeout members, please give me this permission to continue."
 msgstr ""
 
-#: warnsystem/api.py:1100
+#: warnsystem/api.py:1094
 msgid "I can't kick members, please give me this permission to continue."
 msgstr ""
 
-#: warnsystem/api.py:1106
+#: warnsystem/api.py:1100
 msgid "I can't ban members, please give me this permission to continue."
 msgstr ""
 
-#: warnsystem/api.py:1112
+#: warnsystem/api.py:1106
 msgid ""
 "[WarnSystem] {action} requested by {author} (ID: {author.id}) against "
 "{member}. "
 msgstr ""
 
-#: warnsystem/api.py:1118
+#: warnsystem/api.py:1112
 msgid ""
 "\n"
 "\n"
 "Duration: {time} "
 msgstr ""
 
-#: warnsystem/api.py:1121
+#: warnsystem/api.py:1115
 msgid "Reason: {reason}"
 msgstr ""
 
-#: warnsystem/api.py:1123
+#: warnsystem/api.py:1117
 msgid "Reason too long to be shown."
 msgstr ""
 
-#: warnsystem/api.py:1161
+#: warnsystem/api.py:1155
 msgid ""
 "You were unbanned from {guild}, your temporary ban (reason: {reason}) just ended after {duration}.\n"
 "You can join back using this invite: {invite}"
 msgstr ""
 
-#: warnsystem/api.py:1206
+#: warnsystem/api.py:1196
 msgid ""
 "End of timed {action} of {member} requested by {author} that lasted for "
 "{time}. Reason of the {action}: {reason}"
 msgstr ""
 
-#: warnsystem/api.py:1469
+#: warnsystem/api.py:1476
 msgid "{member} you're sending messages too fast!"
 msgstr ""
 
@@ -337,7 +306,7 @@ msgstr ""
 msgid "Invalid time format."
 msgstr ""
 
-#: warnsystem/automod.py:68 warnsystem/automod.py:69 warnsystem/automod.py:244
+#: warnsystem/automod.py:68 warnsystem/automod.py:69 warnsystem/automod.py:247
 msgid "Not set."
 msgstr ""
 
@@ -366,7 +335,8 @@ msgid "Lock to level: {level}\n"
 msgstr ""
 
 #: warnsystem/automod.py:79 warnsystem/automod.py:134
-#: warnsystem/automod.py:529 warnsystem/automod.py:549
+#: warnsystem/automod.py:274 warnsystem/automod.py:564
+#: warnsystem/automod.py:584
 msgid "disabled"
 msgstr ""
 
@@ -441,16 +411,16 @@ msgid ""
 "Type `{prefix}automod enable {arg}` to {action} it."
 msgstr ""
 
-#: warnsystem/automod.py:134 warnsystem/automod.py:525
-#: warnsystem/automod.py:549
+#: warnsystem/automod.py:134 warnsystem/automod.py:274
+#: warnsystem/automod.py:560 warnsystem/automod.py:584
 msgid "enabled"
 msgstr ""
 
-#: warnsystem/automod.py:137
+#: warnsystem/automod.py:137 warnsystem/automod.py:277
 msgid "enable"
 msgstr ""
 
-#: warnsystem/automod.py:137
+#: warnsystem/automod.py:137 warnsystem/automod.py:277
 msgid "disable"
 msgstr ""
 
@@ -539,30 +509,53 @@ msgstr ""
 msgid "Regular expression"
 msgstr ""
 
-#: warnsystem/automod.py:238 warnsystem/automod.py:704
-#: warnsystem/warnsystem.py:815
+#: warnsystem/automod.py:240 warnsystem/automod.py:824
+#: warnsystem/components.py:265 warnsystem/components.py:296
+#: warnsystem/warnsystem.py:739
 msgid "Warning"
 msgstr ""
 
-#: warnsystem/automod.py:239
+#: warnsystem/automod.py:241
 msgid ""
 "**Level:** {level}\n"
 "**Reason:** {reason}\n"
 "**Duration:** {time}"
 msgstr ""
 
-#: warnsystem/automod.py:252
+#: warnsystem/automod.py:256
+#, docstring
+msgid ""
+"\n"
+"        Defines if the bot should check edited messages.\n"
+"        "
+msgstr ""
+
+#: warnsystem/automod.py:263
+msgid "The bot will now check edited messages."
+msgstr ""
+
+#: warnsystem/automod.py:266
+msgid "The bot will no longer check edited messages."
+msgstr ""
+
+#: warnsystem/automod.py:270
+msgid ""
+"Edited message check is currently {state}.\n"
+"Type `{prefix}automod regex edited {arg}` to {action} it."
+msgstr ""
+
+#: warnsystem/automod.py:283
 #, docstring
 msgid ""
 "\n"
 "                Trigger actions when a member get x warnings within the specified time.\n"
 "\n"
-"        For example, if a member gets 3 warnings within a day, you can make the bot automatically set him a level 3 warning with the given reason.\n"
+"        For example, if a member gets 3 warnings within a day, you can make the bot automatically set them a level 3 warning with the given reason.\n"
 "        It is also possible to only include warnings given by the bot when counting.\n"
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:263
+#: warnsystem/automod.py:294
 #, docstring
 msgid ""
 "\n"
@@ -572,62 +565,62 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:269
+#: warnsystem/automod.py:300
 msgid "Loading configuration menu..."
 msgstr ""
 
-#: warnsystem/automod.py:271
+#: warnsystem/automod.py:302
 msgid "Automatic warn setup"
 msgstr ""
 
-#: warnsystem/automod.py:279
+#: warnsystem/automod.py:310
 msgid "How many warnings should trigger the automod?"
 msgstr ""
 
-#: warnsystem/automod.py:285
+#: warnsystem/automod.py:316
 msgid "This must be higher than 1."
 msgstr ""
 
-#: warnsystem/automod.py:291
+#: warnsystem/automod.py:322
 msgid "What's the level of the automod's warning?"
 msgstr ""
 
-#: warnsystem/automod.py:297
+#: warnsystem/automod.py:328
 msgid "Level must be between 1 and 5."
 msgstr ""
 
-#: warnsystem/automod.py:299
+#: warnsystem/automod.py:333
 msgid "What's the reason of the automod's warning?"
 msgstr ""
 
-#: warnsystem/automod.py:305
+#: warnsystem/automod.py:340
 msgid ""
 "For how long should this automod be active?\n"
 "\n"
 "For example, you can make it trigger if a member got 3 warnings __within a day__\n"
 "Omitting this value will make the automod look across the entire member's modlog without time limit.\n"
 "\n"
-"Format is the same as temp mutes/bans: `30m` = 30 minutes, `2h` = 2 hours, `4d` = 4 days..."
+"Format is the same as timeouts/temp bans: `30m` = 30 minutes, `2h` = 2 hours, `4d` = 4 days..."
 msgstr ""
 
-#: warnsystem/automod.py:322
+#: warnsystem/automod.py:357
 msgid ""
-"Level 2 and 5 warnings can be temporary (unmute or unban after some time). For how long should the the member stay punished?\n"
-"Skip this value to make the mute/ban unlimited.\n"
+"Level 2 have to be and Level 5 warnings can be temporary (unban after some time). For how long should the the member stay punished?\n"
+"Skip this value for bans to make it unlimited.\n"
 "Time format is the same as the previous question."
 msgstr ""
 
-#: warnsystem/automod.py:336
+#: warnsystem/automod.py:371
 msgid ""
 "Should the automod be triggered only by specific level? (e.g. only 3 level 1 warnings should trigger)\n"
 "Send the level or `0` to disable."
 msgstr ""
 
-#: warnsystem/automod.py:346
+#: warnsystem/automod.py:381
 msgid "Level must be between 0 and 5."
 msgstr ""
 
-#: warnsystem/automod.py:352
+#: warnsystem/automod.py:387
 msgid ""
 "Should the automod be triggered only by other automod warnings?\n"
 "If enabled, warnings issued by a normal moderator will not be added to the count.\n"
@@ -635,28 +628,28 @@ msgid ""
 "Type `yes` or `no`."
 msgstr ""
 
-#: warnsystem/automod.py:362 warnsystem/automod.py:383
-#: warnsystem/automod.py:440
+#: warnsystem/automod.py:397 warnsystem/automod.py:418
+#: warnsystem/automod.py:475
 msgid "Timed out."
 msgstr ""
 
-#: warnsystem/automod.py:365
+#: warnsystem/automod.py:400
 msgid "Summary of auto warn"
 msgstr ""
 
-#: warnsystem/automod.py:376
+#: warnsystem/automod.py:411
 msgid "Is this correct?"
 msgstr ""
 
-#: warnsystem/automod.py:386
+#: warnsystem/automod.py:421
 msgid "Please restart the process over."
 msgstr ""
 
-#: warnsystem/automod.py:402
+#: warnsystem/automod.py:437
 msgid "The new automatic warn was successfully saved!"
 msgstr ""
 
-#: warnsystem/automod.py:406
+#: warnsystem/automod.py:441
 #, docstring
 msgid ""
 "\n"
@@ -666,31 +659,31 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:413 warnsystem/automod.py:484
+#: warnsystem/automod.py:448 warnsystem/automod.py:519
 msgid "Invalid index, must be positive."
 msgstr ""
 
-#: warnsystem/automod.py:419 warnsystem/automod.py:490
+#: warnsystem/automod.py:454 warnsystem/automod.py:525
 msgid "There isn't such automated warn."
 msgstr ""
 
-#: warnsystem/automod.py:421
+#: warnsystem/automod.py:456
 msgid "Deletion of the following auto warn:"
 msgstr ""
 
-#: warnsystem/automod.py:433
+#: warnsystem/automod.py:468
 msgid "Confirm with the reactions below."
 msgstr ""
 
-#: warnsystem/automod.py:443
+#: warnsystem/automod.py:478
 msgid "The auto warn wasn't deleted."
 msgstr ""
 
-#: warnsystem/automod.py:446
+#: warnsystem/automod.py:481
 msgid "Automated warning successfully deleted."
 msgstr ""
 
-#: warnsystem/automod.py:450
+#: warnsystem/automod.py:485
 #, docstring
 msgid ""
 "\n"
@@ -698,27 +691,27 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:456
+#: warnsystem/automod.py:491
 msgid "No automatic warn registered."
 msgstr ""
 
-#: warnsystem/automod.py:460
+#: warnsystem/automod.py:495
 msgid "{index}. level {level} warn (need {number} warns to trigger)\n"
 msgstr ""
 
-#: warnsystem/automod.py:467
+#: warnsystem/automod.py:502
 msgid ""
 "Page {i}/{total}\n"
 "\n"
 msgstr ""
 
-#: warnsystem/automod.py:469
+#: warnsystem/automod.py:504
 msgid ""
 "\n"
 "*Type `{prefix}automod warn show` to view details.*"
 msgstr ""
 
-#: warnsystem/automod.py:477
+#: warnsystem/automod.py:512
 #, docstring
 msgid ""
 "\n"
@@ -728,11 +721,11 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:492
+#: warnsystem/automod.py:527
 msgid "Settings of auto warn {index}"
 msgstr ""
 
-#: warnsystem/automod.py:508
+#: warnsystem/automod.py:543
 #, docstring
 msgid ""
 "\n"
@@ -742,7 +735,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:518
+#: warnsystem/automod.py:553
 #, docstring
 msgid ""
 "\n"
@@ -750,23 +743,23 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:526
+#: warnsystem/automod.py:561
 msgid "Disable"
 msgstr ""
 
-#: warnsystem/automod.py:527
+#: warnsystem/automod.py:562
 msgid "False"
 msgstr ""
 
-#: warnsystem/automod.py:530
+#: warnsystem/automod.py:565
 msgid "Enable"
 msgstr ""
 
-#: warnsystem/automod.py:531
+#: warnsystem/automod.py:566
 msgid "True"
 msgstr ""
 
-#: warnsystem/automod.py:533
+#: warnsystem/automod.py:568
 msgid ""
 "WarnSystem's antispam feature will make your text channels cleaner by removing and warning members sending undesired content.\n"
 "\n"
@@ -774,17 +767,17 @@ msgid ""
 "{status_change} it with `{prefix}automod antispam enable {setting}`."
 msgstr ""
 
-#: warnsystem/automod.py:548
+#: warnsystem/automod.py:583
 msgid "Antispam system is now {status}."
 msgstr ""
 
-#: warnsystem/automod.py:552
+#: warnsystem/automod.py:587
 msgid ""
 "\n"
 ":warning: Automod isn't enabled on this guild, enable it with `{prefix}automod enable True`."
 msgstr ""
 
-#: warnsystem/automod.py:562
+#: warnsystem/automod.py:597
 #, docstring
 msgid ""
 "\n"
@@ -795,38 +788,38 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:574
+#: warnsystem/automod.py:609
 msgid ""
-"Done. A member will be considered as spamming if he sends more than "
+"Done. A member will be considered as spamming if they sends more than "
 "{max_messages} within {delay} seconds."
 msgstr ""
 
-#: warnsystem/automod.py:582
+#: warnsystem/automod.py:617
 #, docstring
 msgid ""
 "\n"
 "        If antispam is triggered twice within this delay, perform the warn.\n"
 "\n"
 "        Delay in seconds.\n"
-"        If the antispam is triggered once, a simple warning is send in the chat, mentionning themember. If the same member triggers the antispam system a second time within this delay, therewill be an actual warning taken, the one you define with `[p]automod antispam warn`.\n"
+"        If the antispam is triggered once, a simple warning is send in the chat, mentioning themember. If the same member triggers the antispam system a second time within this delay, therewill be an actual warning taken, the one you define with `[p]automod antispam warn`.\n"
 "\n"
-"        This is a way to tell the member he is close to being sanctioned. Of course you candisable this and immediatly take actions by setting a delay of 0. Default is 60 seconds.\n"
+"        This is a way to tell the member they are close to being sanctioned. Of course you candisable this and immediately take actions by setting a delay of 0. Default is 60 seconds.\n"
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:598
+#: warnsystem/automod.py:633
 msgid ""
 "Done. If the antispam is triggered twice within {time} seconds, actions will"
 " be taken. Use `{prefix}automod antispam warn` to define the warn taken."
 msgstr ""
 
-#: warnsystem/automod.py:606
+#: warnsystem/automod.py:641
 msgid ""
 "Done. When triggered, the antispam will immediately perform the warn you "
 "defined with `{prefix}automod antispam warn`."
 msgstr ""
 
-#: warnsystem/automod.py:621
+#: warnsystem/automod.py:656
 #, docstring
 msgid ""
 "\n"
@@ -835,21 +828,97 @@ msgid ""
 "        The arguments for this command works the same way as the warn command.\n"
 "        Examples: `[p]automod antispam warn 1 Spamming` `[p]automod antispam warn 2 30m Spamming`\n"
 "\n"
-"        You can use the `[p]automod warn` command to configure an automatic warning after multipleautomod infractions, like a mute after 3 warns.\n"
+"        You can use the `[p]automod warn` command to configure an automatic warning after multiple        automod infractions, like a timeout after 3 warns.\n"
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:640
+#: warnsystem/automod.py:675
 msgid ""
-"If the antispam is triggered by a member, he will now receive a level {level} warn {duration}for the following reason:\n"
+"If the antispam is triggered by a member, they will now receive a level {level} warn {duration}for the following reason:\n"
 "{reason}"
 msgstr ""
 
-#: warnsystem/automod.py:646
+#: warnsystem/automod.py:682
 msgid "that will last for {time} "
 msgstr ""
 
-#: warnsystem/automod.py:656
+#: warnsystem/automod.py:693
+#, docstring
+msgid ""
+"\n"
+"        Manage word whitelist ignored for antispam.\n"
+"        "
+msgstr ""
+
+#: warnsystem/automod.py:700
+#, docstring
+msgid ""
+"\n"
+"        Add multiple words for the whitelist.\n"
+"\n"
+"        If you want to add words with spaces, use quotes.\n"
+"        "
+msgstr ""
+
+#: warnsystem/automod.py:712
+msgid "`{word}` is already in the whitelist."
+msgstr ""
+
+#: warnsystem/automod.py:717
+msgid "Added one word to the whitelist."
+msgstr ""
+
+#: warnsystem/automod.py:719
+msgid "Added {num} words to the whitelist."
+msgstr ""
+
+#: warnsystem/automod.py:723
+#, docstring
+msgid ""
+"\n"
+"        Remove multiple words for the whitelist.\n"
+"\n"
+"        If you want to remove words with spaces, use quotes.\n"
+"        "
+msgstr ""
+
+#: warnsystem/automod.py:735
+msgid "`{word}` isn't in the whitelist."
+msgstr ""
+
+#: warnsystem/automod.py:740
+msgid "Removed one word from the whitelist."
+msgstr ""
+
+#: warnsystem/automod.py:742
+msgid "Removed {num} words from the whitelist."
+msgstr ""
+
+#: warnsystem/automod.py:746
+#, docstring
+msgid ""
+"\n"
+"        List words in the whitelist.\n"
+"        "
+msgstr ""
+
+#: warnsystem/automod.py:752
+msgid "Whitelist is empty."
+msgstr ""
+
+#: warnsystem/automod.py:754
+msgid "__{num} words registered in the whitelist__\n"
+msgstr ""
+
+#: warnsystem/automod.py:762
+#, docstring
+msgid ""
+"\n"
+"        Clear the whitelist.\n"
+"        "
+msgstr ""
+
+#: warnsystem/automod.py:772
 #, docstring
 msgid ""
 "\n"
@@ -857,48 +926,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/automod.py:662
+#: warnsystem/automod.py:778
 msgid "Antispam system settings"
 msgstr ""
 
-#: warnsystem/automod.py:665
+#: warnsystem/automod.py:781
 msgid ":white_check_mark: Antispam system: **Enabled**\n"
 msgstr ""
 
-#: warnsystem/automod.py:667
+#: warnsystem/automod.py:783
 msgid ":x: Antispam system: **Disabled**\n"
 msgstr ""
 
-#: warnsystem/automod.py:669
+#: warnsystem/automod.py:785
 msgid ":white_check_mark: WarnSystem automod: **Enabled**\n"
 msgstr ""
 
-#: warnsystem/automod.py:671
+#: warnsystem/automod.py:787
 msgid ""
 ":x: WarnSystem automod: **Disabled**\n"
 ":warning: The antispam won't work if the automod is disabled."
 msgstr ""
 
-#: warnsystem/automod.py:677
+#: warnsystem/automod.py:793
 msgid "Settings"
 msgstr ""
 
-#: warnsystem/automod.py:678
+#: warnsystem/automod.py:794
 msgid ""
 "Max messages allowed within the threshold: **{max_messages}**\n"
 "Threshold: **{delay} seconds**\n"
-"Delay before reset: **{reset_delay} seconds**  *(see `{prefix}automod antispam delay` for details about this)*"
+"Delay before reset: **{reset_delay} seconds**  *(see `{prefix}automod antispam delay` for details about this)*\n"
+"Number of whitelisted words: {whitelist}"
 msgstr ""
 
-#: warnsystem/automod.py:694
+#: warnsystem/automod.py:812
 msgid "Time: {time}\n"
 msgstr ""
 
-#: warnsystem/automod.py:699
+#: warnsystem/automod.py:818
 msgid "Unlimited."
 msgstr ""
 
-#: warnsystem/automod.py:705
+#: warnsystem/automod.py:825
 msgid ""
 "This is the warning members will get when they break the antispam:\n"
 "\n"
@@ -906,21 +976,166 @@ msgid ""
 "{time}Reason: {reason}"
 msgstr ""
 
-#: warnsystem/converters.py:145
+#: warnsystem/components.py:43
+msgid "{amount} {unit} ago"
+msgstr ""
+
+#: warnsystem/components.py:62
+msgid "Just now"
+msgstr ""
+
+#: warnsystem/components.py:66
+msgid "A minute ago"
+msgstr ""
+
+#: warnsystem/components.py:70
+msgid "An hour ago"
+msgstr ""
+
+#: warnsystem/components.py:74
+msgid "Yesterday"
+msgstr ""
+
+#: warnsystem/components.py:139 warnsystem/settings.py:237
+#: warnsystem/settings.py:246 warnsystem/settings.py:280
+msgid "Request timed out."
+msgstr ""
+
+#: warnsystem/components.py:146
+msgid "Cancelled."
+msgstr ""
+
+#: warnsystem/components.py:157 warnsystem/components.py:201
+msgid "New reason"
+msgstr ""
+
+#: warnsystem/components.py:158
+msgid "Enter the new reason here, substitutions work."
+msgstr ""
+
+#: warnsystem/components.py:199
+msgid "Case #{number} edition."
+msgstr ""
+
+#: warnsystem/components.py:200
+msgid "Old reason"
+msgstr ""
+
+#: warnsystem/components.py:202
+msgid "Click on ✅ to confirm the changes."
+msgstr ""
+
+#: warnsystem/components.py:209
+msgid "The reason was successfully edited!\n"
+msgstr ""
+
+#: warnsystem/components.py:222
+msgid ""
+"Case #{number} deletion.\n"
+"**Click on the button to confirm your action.**"
+msgstr ""
+
+#: warnsystem/components.py:233
+msgid "The case was successfully deleted!"
+msgstr ""
+
+#: warnsystem/components.py:267 warnsystem/components.py:297
+#: warnsystem/warnsystem.py:740
+msgid "Timeout"
+msgstr ""
+
+#: warnsystem/components.py:269 warnsystem/components.py:298
+#: warnsystem/warnsystem.py:741
+msgid "Kick"
+msgstr ""
+
+#: warnsystem/components.py:271 warnsystem/components.py:299
+#: warnsystem/warnsystem.py:742
+msgid "Softban"
+msgstr ""
+
+#: warnsystem/components.py:273 warnsystem/components.py:300
+#: warnsystem/warnsystem.py:743
+msgid "Ban"
+msgstr ""
+
+#: warnsystem/components.py:296 warnsystem/warnsystem.py:739
+msgid "Warnings"
+msgstr ""
+
+#: warnsystem/components.py:297 warnsystem/warnsystem.py:740
+msgid "Timeouts"
+msgstr ""
+
+#: warnsystem/components.py:298 warnsystem/warnsystem.py:741
+msgid "Kicks"
+msgstr ""
+
+#: warnsystem/components.py:299 warnsystem/warnsystem.py:742
+msgid "Softbans"
+msgstr ""
+
+#: warnsystem/components.py:300 warnsystem/warnsystem.py:743
+msgid "Bans"
+msgstr ""
+
+#: warnsystem/components.py:313
+msgid "Case #{number} informations"
+msgstr ""
+
+#: warnsystem/components.py:318
+msgid "Level"
+msgstr ""
+
+#: warnsystem/components.py:325
+msgid ""
+"{duration}\n"
+"(Until {date})"
+msgstr ""
+
+#: warnsystem/context_menus.py:63 warnsystem/context_menus.py:66
+msgid "Invalid duration"
+msgstr ""
+
+#: warnsystem/context_menus.py:73
+msgid "You must input a number, not {}"
+msgstr ""
+
+#: warnsystem/context_menus.py:79
+msgid "The number of days must be between 1 and 7."
+msgstr ""
+
+#: warnsystem/context_menus.py:91 warnsystem/warnsystem.py:217
+msgid "Done."
+msgstr ""
+
+#: warnsystem/context_menus.py:145
+msgid "The WarnSystem cog is not loaded"
+msgstr ""
+
+#: warnsystem/context_menus.py:153
+msgid "You are not allowed to do this"
+msgstr ""
+
+#: warnsystem/context_menus.py:157
+msgid "Please choose an action to perform."
+msgstr ""
+
+#: warnsystem/converters.py:152
 msgid ""
 "I'm not doing anything! Please provide at least one of these arguments: "
 "`--take-action`, `--send-dm`, `--send-modlog`."
 msgstr ""
 
-#: warnsystem/converters.py:151
+#: warnsystem/converters.py:158
 msgid "Can't combine `--only-humans` with `--only-bots`."
 msgstr ""
 
-#: warnsystem/converters.py:221
+#: warnsystem/converters.py:232
 msgid "The search could't find any member."
 msgstr ""
 
-#: warnsystem/converters.py:254
+#: warnsystem/converters.py:265
 msgid ""
 "Can't convert `{arg}` from `--joined-{state}` into a valid date object. Here are some examples of the date format you must follow:\n"
 "- `February 14 at 6pm`\n"
@@ -928,38 +1143,38 @@ msgid ""
 "- `jan 4 16:09`"
 msgstr ""
 
-#: warnsystem/converters.py:305
+#: warnsystem/converters.py:316
 msgid ""
 "Can't convert `{arg}` from `--has-{state}` into a valid permission object. "
 "Please provide something like this: `send_messages`"
 msgstr ""
 
-#: warnsystem/converters.py:346
+#: warnsystem/converters.py:362
 msgid ""
 "Can't convert `{arg}` from `--{state}` into a valid role object. Please "
 "provide the exact role name (in quotes if it has spaces) or an ID."
 msgstr ""
 
-#: warnsystem/converters.py:393
+#: warnsystem/converters.py:409
 msgid ""
 "Can't convert `{arg}` from `--{state}` into a valid member object. Please "
 "provide the exact member's name (in quotes if it has spaces), mention him, "
 "or provide its ID."
 msgstr ""
 
-#: warnsystem/converters.py:414
+#: warnsystem/converters.py:430
 msgid ""
 "Can't convert `{arg}` from `--hackban-select` into a valid user object. "
 "__You can only provide a user ID.__"
 msgstr ""
 
-#: warnsystem/converters.py:432
+#: warnsystem/converters.py:449
 msgid ""
 "Can't convert `{arg}` from `--time`/`--length` into a valid time object.\n"
 "Examples of the format: `20m`, `2h30m`, `7d`, `1d6h30m45s`"
 msgstr ""
 
-#: warnsystem/converters.py:464
+#: warnsystem/converters.py:481
 msgid "`{arg}` is not a valid regex pattern. {e}"
 msgstr ""
 
@@ -974,42 +1189,6 @@ msgid ""
 msgstr ""
 
 #: warnsystem/settings.py:43
-#, docstring
-msgid ""
-"\n"
-"        Defines if the bot should update permissions of new channels for the mute role.\n"
-"\n"
-"        If enabled, for each new text channel and category created, the Mute role will be        denied the permission to send messages and add reactions here.\n"
-"        Keeping this disabled might cause issues with channels created after the WarnSystem setup        where muted members can talk.\n"
-"        "
-msgstr ""
-
-#: warnsystem/settings.py:55
-msgid ""
-"The bot currently {update} new channels. If you want to change this, type "
-"`[p]warnset autoupdate {opposite}`."
-msgstr ""
-
-#: warnsystem/settings.py:59
-msgid "updates"
-msgstr ""
-
-#: warnsystem/settings.py:59
-msgid "doesn't update"
-msgstr ""
-
-#: warnsystem/settings.py:65
-msgid ""
-"Done. New created channels will be updated to keep the mute role working."
-msgstr ""
-
-#: warnsystem/settings.py:70
-msgid ""
-"Done. New created channels won't be updated.\n"
-"**Make sure to update manually new channels to keep the mute role working as intended.**"
-msgstr ""
-
-#: warnsystem/settings.py:78
 #, docstring
 msgid ""
 "\n"
@@ -1032,33 +1211,33 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:101
+#: warnsystem/settings.py:66
 msgid ""
 "The first argument must be `ban` or `softban`.\n"
 "Type `{prefix}help warnset bandays` for more details."
 msgstr ""
 
-#: warnsystem/settings.py:108
+#: warnsystem/settings.py:73
 msgid "You can set 0 to disable messages deletion."
 msgstr ""
 
-#: warnsystem/settings.py:110
+#: warnsystem/settings.py:75
 msgid ""
 "The number of days of messages to delete must be between 1 and 7, due to "
 "Discord restrictions.\n"
 msgstr ""
 
-#: warnsystem/settings.py:119
+#: warnsystem/settings.py:84
 msgid ""
 "The goal of a softban is to delete the members' messages. Disabling this "
 "would make the softban a simple kick. Enter a value between 1 and 7."
 msgstr ""
 
-#: warnsystem/settings.py:129
+#: warnsystem/settings.py:94
 msgid "The new value was successfully set!"
 msgstr ""
 
-#: warnsystem/settings.py:135
+#: warnsystem/settings.py:100
 #, docstring
 msgid ""
 "\n"
@@ -1073,15 +1252,15 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:148
+#: warnsystem/settings.py:113
 msgid "I don't have the permission to send messages in that channel."
 msgstr ""
 
-#: warnsystem/settings.py:150
+#: warnsystem/settings.py:115
 msgid "I don't have the permissions to send embed links in that channel."
 msgstr ""
 
-#: warnsystem/settings.py:155
+#: warnsystem/settings.py:120
 msgid ""
 "Done. All events will be send to that channel by default.\n"
 "\n"
@@ -1089,17 +1268,17 @@ msgid ""
 "Example: `{prefix}warnset channel #your-channel 3`"
 msgstr ""
 
-#: warnsystem/settings.py:164
+#: warnsystem/settings.py:129
 msgid ""
 "If you want to specify a level for the channel, provide a number between 1 "
 "and 5."
 msgstr ""
 
-#: warnsystem/settings.py:172
+#: warnsystem/settings.py:137
 msgid "Done. All level {level} warnings events will be sent to that channel."
 msgstr ""
 
-#: warnsystem/settings.py:179
+#: warnsystem/settings.py:144
 #, docstring
 msgid ""
 "\n"
@@ -1112,17 +1291,17 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:189 warnsystem/settings.py:387
-#: warnsystem/settings.py:971
+#: warnsystem/settings.py:154 warnsystem/settings.py:351
+#: warnsystem/settings.py:736
 msgid "You must provide a level between 1 and 5."
 msgstr ""
 
-#: warnsystem/settings.py:193
+#: warnsystem/settings.py:158
 msgid ""
 "The new color for level {level} warnings has been succesfully set to {color}"
 msgstr ""
 
-#: warnsystem/settings.py:200
+#: warnsystem/settings.py:165
 #, docstring
 msgid ""
 "\n"
@@ -1137,36 +1316,31 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:251
+#: warnsystem/settings.py:215
 msgid "That path doesn't exist."
 msgstr ""
 
-#: warnsystem/settings.py:254
+#: warnsystem/settings.py:218
 msgid "That's not a valid file."
 msgstr ""
 
-#: warnsystem/settings.py:259
+#: warnsystem/settings.py:223
 msgid ""
 "It looks like that file doesn't belong to the current server. Are you sure "
 "you want to use this file?"
 msgstr ""
 
-#: warnsystem/settings.py:273 warnsystem/settings.py:282
-#: warnsystem/settings.py:316
-msgid "Request timed out."
-msgstr ""
-
-#: warnsystem/settings.py:285
+#: warnsystem/settings.py:249
 msgid "Alrght, try again with the good file."
 msgstr ""
 
-#: warnsystem/settings.py:296
+#: warnsystem/settings.py:260
 msgid ""
 "Couln't read the file because of an exception. Check your console or logs "
 "for details."
 msgstr ""
 
-#: warnsystem/settings.py:303
+#: warnsystem/settings.py:267
 msgid ""
 "Would you like to **append** the logs or **overwrite** them?\n"
 "\n"
@@ -1176,29 +1350,29 @@ msgid ""
 "*Type* `append` *or* `overwrite` *in the chat.*"
 msgstr ""
 
-#: warnsystem/settings.py:311
+#: warnsystem/settings.py:275
 msgid "append"
 msgstr ""
 
-#: warnsystem/settings.py:311
+#: warnsystem/settings.py:275
 msgid "overwrite"
 msgstr ""
 
-#: warnsystem/settings.py:320 warnsystem/settings.py:325
+#: warnsystem/settings.py:284 warnsystem/settings.py:289
 msgid "Starting conversion... This might take a long time."
 msgstr ""
 
-#: warnsystem/settings.py:323
+#: warnsystem/settings.py:287
 msgid "Deleting server logs... Settings, such as channels, are kept."
 msgstr ""
 
-#: warnsystem/settings.py:329
+#: warnsystem/settings.py:293
 msgid ""
 "Done! {number} cases were added to the WarnSystem V3 log.\n"
 "This took {time} seconds."
 msgstr ""
 
-#: warnsystem/settings.py:345
+#: warnsystem/settings.py:309
 #, docstring
 msgid ""
 "\n"
@@ -1213,7 +1387,7 @@ msgid ""
 "        - `{invite}`: Generate an invite for the server\n"
 "        - `{member}`: The warned member (tip: you can use `{member.id}` for the member's ID or        `{member.mention}` for a mention)\n"
 "        - `{mod}`: The moderator that warned the member (you can also use keys like        `{moderator.id}`)\n"
-"        - `{duration}`: The duration of a timed mute/ban if it exists\n"
+"        - `{duration}`: The duration of a timed timeout/ban if it exists\n"
 "        - `{time}`: The current date and time.\n"
 "\n"
 "        __Examples:__\n"
@@ -1229,60 +1403,61 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:380
+#: warnsystem/settings.py:344
 msgid ""
 "You need to specify `modlog` or `user`. Read the help of the command for "
 "more details."
 msgstr ""
 
-#: warnsystem/settings.py:396
+#: warnsystem/settings.py:360
 msgid ""
 "The new description for {destination} (warn {level}) was successfully set!"
 msgstr ""
 
-#: warnsystem/settings.py:397
+#: warnsystem/settings.py:361
 msgid "modlog"
 msgstr ""
 
-#: warnsystem/settings.py:397 warnsystem/warnsystem.py:389
+#: warnsystem/settings.py:361 warnsystem/warnsystem.py:309
 msgid "user"
 msgstr ""
 
-#: warnsystem/settings.py:403
+#: warnsystem/settings.py:368
 #, docstring
 msgid ""
 "\n"
-"        Defines if the bot should log manual bans to WarnSystem.\n"
+"        Defines if the bot should log manual kicks/bans with WarnSystem.\n"
 "\n"
 "        If enabled, manually banning a member will make the bot log the action in the modlog andsave it, as if it was performed with WarnSystem. **However, the member will not receive a DM**.\n"
-"        \n"
+"        This also works with kicks, but not timeouts *yet*.\n"
+"\n"
 "        Invoke the command without arguments to get the current status.\n"
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:415
+#: warnsystem/settings.py:381
 msgid ""
-"The bot currently {detect} manual bans. If you want to change this, type "
+"The bot currently {detect} manual actions. If you want to change this, type "
 "`{prefix}warnset detectmanual {opposite}`."
 msgstr ""
 
-#: warnsystem/settings.py:419
+#: warnsystem/settings.py:385
 msgid "detects"
 msgstr ""
 
-#: warnsystem/settings.py:419
+#: warnsystem/settings.py:385
 msgid "doesn't detect"
 msgstr ""
 
-#: warnsystem/settings.py:426
-msgid "Done. The bot will now listen for manual bans and log them."
+#: warnsystem/settings.py:392
+msgid "Done. The bot will now listen for manual actions and log them."
 msgstr ""
 
-#: warnsystem/settings.py:429
-msgid "Done. The bot won't listen for manual bans anymore."
+#: warnsystem/settings.py:395
+msgid "Done. The bot won't listen for manual actions anymore."
 msgstr ""
 
-#: warnsystem/settings.py:433
+#: warnsystem/settings.py:399
 #, docstring
 msgid ""
 "\n"
@@ -1295,136 +1470,33 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:446
+#: warnsystem/settings.py:412
 msgid ""
 "The bot currently {respect} role hierarchy. If you want to change this, type"
 " `[p]warnset hierarchy {opposite}`."
 msgstr ""
 
-#: warnsystem/settings.py:450
+#: warnsystem/settings.py:416
 msgid "respects"
 msgstr ""
 
-#: warnsystem/settings.py:450
+#: warnsystem/settings.py:416
 msgid "doesn't respect"
 msgstr ""
 
-#: warnsystem/settings.py:457
+#: warnsystem/settings.py:423
 msgid ""
 "Done. Moderators will not be able to take actions on the members higher than"
 " themselves in the role hierarchy of the server."
 msgstr ""
 
-#: warnsystem/settings.py:465
+#: warnsystem/settings.py:431
 msgid ""
 "Done. Moderators will be able to take actions on anyone on the server, as "
 "long as the bot is able to do so."
 msgstr ""
 
-#: warnsystem/settings.py:473
-#, docstring
-msgid ""
-"\n"
-"        Create the role used for muting members.\n"
-"\n"
-"        You can specify a role when invoking the command to specify which role should be used.\n"
-"        If you don't specify a role, one will be created for you.\n"
-"        "
-msgstr ""
-
-#: warnsystem/settings.py:492
-msgid ""
-"A mute role was already created! You can change it by specifying a role when typing the command.\n"
-"`[p]warnset mute <role name>`"
-msgstr ""
-
-#: warnsystem/settings.py:500
-msgid ""
-"\n"
-"\n"
-"Some errors occured when editing the channel permissions:\n"
-msgstr ""
-
-#: warnsystem/settings.py:506
-msgid ""
-"The role `Muted` was successfully created at position {pos}. Feel free to "
-"drag it in the hierarchy and edit its permissions, as long as my top role is"
-" above and the members to mute are below."
-msgstr ""
-
-#: warnsystem/settings.py:517
-msgid ""
-"That role is higher than my top role in the hierarchy. Please move it below "
-"\"{bot_role}\"."
-msgstr ""
-
-#: warnsystem/settings.py:524
-msgid "The new mute role was successfully set!"
-msgstr ""
-
-#: warnsystem/settings.py:529
-#, docstring
-msgid ""
-"\n"
-"        Refresh the mute role's permissions in the server.\n"
-"\n"
-"        This will iterate all of your channels and make sure all permissions are correctlyconfigured for the mute role.\n"
-"\n"
-"        The muted role will be prevented from sending messages and adding reactions in all textchannels, and prevented from talking in all voice channels.\n"
-"        "
-msgstr ""
-
-#: warnsystem/settings.py:542
-msgid ""
-"No mute role configured on this server. Create one with `{prefix}warnset "
-"mute`."
-msgstr ""
-
-#: warnsystem/settings.py:551
-msgid ""
-"It looks like the configured mute role was deleted. Create a new one with "
-"`{prefix}warnset mute`."
-msgstr ""
-
-#: warnsystem/settings.py:558
-msgid "I need the `Manage channels` permission to continue."
-msgstr ""
-
-#: warnsystem/settings.py:561
-msgid "Now checking {len} channels, please wait..."
-msgstr ""
-
-#: warnsystem/settings.py:564
-msgid "WarnSystem mute role permissions refresh"
-msgstr ""
-
-#: warnsystem/settings.py:601
-msgid "Successfully checked all channels, {len} were edited."
-msgstr ""
-
-#: warnsystem/settings.py:616
-msgid ""
-"Successfully checked all channels, {len}/{total} were edited.\n"
-"\n"
-msgstr ""
-
-#: warnsystem/settings.py:620
-msgid ""
-"The following channels were not updated due to a permission failure, probably enforced `Manage channels` permission:\n"
-"{channels}\n"
-msgstr ""
-
-#: warnsystem/settings.py:625
-msgid ""
-"The following channels were not updated due to an unknown error (check your logs or ask the bot administrator):\n"
-"{channels}\n"
-msgstr ""
-
-#: warnsystem/settings.py:629
-msgid "You can fix these issues and run the command once again."
-msgstr ""
-
-#: warnsystem/settings.py:635
+#: warnsystem/settings.py:439
 #, docstring
 msgid ""
 "\n"
@@ -1437,69 +1509,32 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:647
+#: warnsystem/settings.py:451
 msgid ""
 "The bot {respect} reinvite unbanned members. If you want to change this, "
 "type `[p]warnset reinvite {opposite}`."
 msgstr ""
 
-#: warnsystem/settings.py:650 warnsystem/settings.py:849
+#: warnsystem/settings.py:454 warnsystem/settings.py:614
 msgid "does"
 msgstr ""
 
-#: warnsystem/settings.py:650 warnsystem/settings.py:849
+#: warnsystem/settings.py:454 warnsystem/settings.py:614
 msgid "doesn't"
 msgstr ""
 
-#: warnsystem/settings.py:655
+#: warnsystem/settings.py:459
 msgid ""
 "Done. The bot will try to send an invite to unbanned members. Please note "
 "that the bot needs to share one server in common with the member to receive "
 "the message."
 msgstr ""
 
-#: warnsystem/settings.py:663
+#: warnsystem/settings.py:467
 msgid "Done. The bot will no longer reinvite unbanned members."
 msgstr ""
 
-#: warnsystem/settings.py:667
-#, docstring
-msgid ""
-"\n"
-"        Defines if the bot should remove all roles on mute\n"
-"\n"
-"        If enabled, when you set a level 2 warning on a member, he will be assigned the mute role        as usual, but all of his other roles will also be removed.\n"
-"        Once the mute ends, the member will get his roles back.\n"
-"        This can be useful for role permissions issues.\n"
-"        "
-msgstr ""
-
-#: warnsystem/settings.py:679
-msgid ""
-"The bot currently {remove} all roles on mute. If you want to change this, "
-"type `[p]warnset removeroles {opposite}`."
-msgstr ""
-
-#: warnsystem/settings.py:683
-msgid "removes"
-msgstr ""
-
-#: warnsystem/settings.py:683
-msgid "doesn't remove"
-msgstr ""
-
-#: warnsystem/settings.py:689
-msgid ""
-"Done. All roles will be removed from muted members. They will get their "
-"roles back once the mute ends or when someone removes the warning using the "
-"`{prefix}warnings` command."
-msgstr ""
-
-#: warnsystem/settings.py:697
-msgid "Done. Muted members will keep their roles on mute."
-msgstr ""
-
-#: warnsystem/settings.py:701
+#: warnsystem/settings.py:471
 #, docstring
 msgid ""
 "\n"
@@ -1507,153 +1542,135 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:706
+#: warnsystem/settings.py:476
 msgid "I can't send embed links here!"
 msgstr ""
 
-#: warnsystem/settings.py:718
+#: warnsystem/settings.py:488
 msgid "Not set. Use `{prefix}warnset channel`"
 msgstr ""
 
-#: warnsystem/settings.py:721
+#: warnsystem/settings.py:491
 msgid "Not found"
 msgstr ""
 
-#: warnsystem/settings.py:723
+#: warnsystem/settings.py:493
 msgid "Default channel: {channel}\n"
 msgstr ""
 
-#: warnsystem/settings.py:725
+#: warnsystem/settings.py:495
 msgid "Level {level} warnings channel: {channel}\n"
 msgstr ""
 
-#: warnsystem/settings.py:729
-msgid "No mute role set."
-msgstr ""
-
-#: warnsystem/settings.py:730 warnsystem/settings.py:731
-#: warnsystem/settings.py:732 warnsystem/settings.py:733
-#: warnsystem/settings.py:734 warnsystem/settings.py:735
+#: warnsystem/settings.py:498 warnsystem/settings.py:499
+#: warnsystem/settings.py:500 warnsystem/settings.py:501
 msgid "Enabled"
 msgstr ""
 
-#: warnsystem/settings.py:730 warnsystem/settings.py:731
-#: warnsystem/settings.py:732 warnsystem/settings.py:733
-#: warnsystem/settings.py:734 warnsystem/settings.py:735
+#: warnsystem/settings.py:498 warnsystem/settings.py:499
+#: warnsystem/settings.py:500 warnsystem/settings.py:501
 msgid "Disabled"
 msgstr ""
 
-#: warnsystem/settings.py:736
+#: warnsystem/settings.py:502
 msgid ""
 "Softban: {softban}\n"
 "Ban: {ban}"
 msgstr ""
 
-#: warnsystem/settings.py:741
+#: warnsystem/settings.py:507
 msgid ""
 "No substitution set.\n"
 "Type `{prefix}help warnset substitutions` to get started."
 msgstr ""
 
-#: warnsystem/settings.py:746
+#: warnsystem/settings.py:512
 msgid ""
 "{number} subsitution{plural} set.\n"
 "Type `{prefix}warnset substitutions list` to list them."
 msgstr ""
 
-#: warnsystem/settings.py:751
+#: warnsystem/settings.py:517
 msgid "s"
 msgstr ""
 
-#: warnsystem/settings.py:762 warnsystem/settings.py:770
+#: warnsystem/settings.py:528 warnsystem/settings.py:536
 msgid "Too long to be shown..."
 msgstr ""
 
-#: warnsystem/settings.py:783
+#: warnsystem/settings.py:549
 msgid "WarnSystem settings. Page 1/2"
 msgstr ""
 
-#: warnsystem/settings.py:784
+#: warnsystem/settings.py:550
 msgid "WarnSystem settings. Page 2/2"
 msgstr ""
 
-#: warnsystem/settings.py:791
+#: warnsystem/settings.py:557
 msgid "You can change all of these values with {prefix}warnset"
 msgstr ""
 
-#: warnsystem/settings.py:794
+#: warnsystem/settings.py:560
 msgid "Cog made with ❤️ by Laggron"
 msgstr ""
 
-#: warnsystem/settings.py:796
+#: warnsystem/settings.py:562
 msgid "Log channels"
 msgstr ""
 
-#: warnsystem/settings.py:797
-msgid "Mute role"
-msgstr ""
-
-#: warnsystem/settings.py:798
+#: warnsystem/settings.py:563
 msgid "Respect hierarchy"
 msgstr ""
 
-#: warnsystem/settings.py:799
+#: warnsystem/settings.py:564
 msgid "Reinvite unbanned members"
 msgstr ""
 
-#: warnsystem/settings.py:800
+#: warnsystem/settings.py:565
 msgid "Show responsible moderator"
 msgstr ""
 
-#: warnsystem/settings.py:801
-msgid "Detect manual bans"
+#: warnsystem/settings.py:566
+msgid "Detect manual actions"
 msgstr ""
 
-#: warnsystem/settings.py:802
-msgid "Update new channels for mute role"
-msgstr ""
-
-#: warnsystem/settings.py:803
-msgid "Remove roles on mute"
-msgstr ""
-
-#: warnsystem/settings.py:804
+#: warnsystem/settings.py:567
 msgid "Days of messages to delete"
 msgstr ""
 
-#: warnsystem/settings.py:805
+#: warnsystem/settings.py:568
 msgid "Substitutions"
 msgstr ""
 
-#: warnsystem/settings.py:806
+#: warnsystem/settings.py:569
 msgid "Embed thumbnails"
 msgstr ""
 
-#: warnsystem/settings.py:807
+#: warnsystem/settings.py:570
 msgid "Embed colors"
 msgstr ""
 
-#: warnsystem/settings.py:809
+#: warnsystem/settings.py:572
 msgid "Modlog embed descriptions"
 msgstr ""
 
-#: warnsystem/settings.py:812
+#: warnsystem/settings.py:577
 msgid "User embed descriptions"
 msgstr ""
 
-#: warnsystem/settings.py:816
+#: warnsystem/settings.py:581
 msgid ""
 "To see informations about the cog (version, documentation, support server, "
 "Patreon), type `{prefix}warnsysteminfo`."
 msgstr ""
 
-#: warnsystem/settings.py:827
+#: warnsystem/settings.py:592
 msgid ""
 "Error when sending the message. Check the warnsystem logs for more "
 "informations."
 msgstr ""
 
-#: warnsystem/settings.py:835
+#: warnsystem/settings.py:600
 #, docstring
 msgid ""
 "\n"
@@ -1665,23 +1682,23 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:846
+#: warnsystem/settings.py:611
 msgid ""
 "The bot {respect} show the responsible moderator to the warned member in DM."
 " If you want to change this, type `[p]warnset showmod {opposite}`."
 msgstr ""
 
-#: warnsystem/settings.py:854
+#: warnsystem/settings.py:619
 msgid ""
 "Done. The moderator responsible of a warn will now be shown to the warned "
 "member in direct messages."
 msgstr ""
 
-#: warnsystem/settings.py:861
+#: warnsystem/settings.py:626
 msgid "Done. The bot will no longer show the responsible moderator."
 msgstr ""
 
-#: warnsystem/settings.py:865
+#: warnsystem/settings.py:630
 #, docstring
 msgid ""
 "\n"
@@ -1696,7 +1713,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:880
+#: warnsystem/settings.py:645
 #, docstring
 msgid ""
 "\n"
@@ -1712,23 +1729,23 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:894
+#: warnsystem/settings.py:659
 msgid ""
 "The name you're using is already used by another substitution!\n"
 "Delete or edit it with `[p]warnset substitutions delete`"
 msgstr ""
 
-#: warnsystem/settings.py:901
+#: warnsystem/settings.py:666
 msgid "That substitution is too long! Maximum is 600 characters!"
 msgstr ""
 
-#: warnsystem/settings.py:905
+#: warnsystem/settings.py:670
 msgid ""
 "Your new subsitutions with the keyword `{keyword}` was successfully created! Type `[{substitution}]` in your warning reason to use the text you just set.\n"
 "Manage your substitutions with the `{prefix}warnset substitutions` subcommands."
 msgstr ""
 
-#: warnsystem/settings.py:915
+#: warnsystem/settings.py:680
 #, docstring
 msgid ""
 "\n"
@@ -1738,17 +1755,17 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:924
+#: warnsystem/settings.py:689
 msgid ""
 "That substitution doesn't exist!\n"
 "See existing substitutions with the `{prefix}warnset substitutions list` command."
 msgstr ""
 
-#: warnsystem/settings.py:931
+#: warnsystem/settings.py:696
 msgid "The substitutions was successfully deleted."
 msgstr ""
 
-#: warnsystem/settings.py:935
+#: warnsystem/settings.py:700
 #, docstring
 msgid ""
 "\n"
@@ -1756,21 +1773,21 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:942
+#: warnsystem/settings.py:707
 msgid ""
 "You don't have any existing substitution on this server!\n"
 "Create one with `{prefix}warnset substitutions add`"
 msgstr ""
 
-#: warnsystem/settings.py:955
+#: warnsystem/settings.py:720
 msgid "Substitutions for {server}:"
 msgstr ""
 
-#: warnsystem/settings.py:957
+#: warnsystem/settings.py:722
 msgid "Page {page}/{max}"
 msgstr ""
 
-#: warnsystem/settings.py:962
+#: warnsystem/settings.py:727
 #, docstring
 msgid ""
 "\n"
@@ -1782,50 +1799,30 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/settings.py:975
+#: warnsystem/settings.py:740
 msgid "The new image for level {level} warnings has been set to {image}."
 msgstr ""
 
-#: warnsystem/warnsystem.py:53
-msgid "{amount} {unit} ago."
-msgstr ""
-
-#: warnsystem/warnsystem.py:72
-msgid "Just now"
-msgstr ""
-
-#: warnsystem/warnsystem.py:76
-msgid "A minute ago"
-msgstr ""
-
-#: warnsystem/warnsystem.py:80
-msgid "An hour ago"
-msgstr ""
-
-#: warnsystem/warnsystem.py:84
-msgid "Yesterday"
-msgstr ""
-
-#: warnsystem/warnsystem.py:110
+#: warnsystem/warnsystem.py:33
 msgid "A member got a level {} warning."
 msgstr ""
 
-#: warnsystem/warnsystem.py:111
+#: warnsystem/warnsystem.py:34
 msgid "The moderation team set you a level {} warning."
 msgstr ""
 
-#: warnsystem/warnsystem.py:127
+#: warnsystem/warnsystem.py:50
 #, docstring
 msgid ""
 "\n"
 "    An alternative to the Red core moderation system, providing a different system of moderation    similar to Dyno.\n"
 "\n"
-"    Report a bug or ask a question: https://discord.gg/AVzjfpR\n"
+"    Report a bug or ask a question: https://discord.gg/GET4DVk\n"
 "    Full documentation and FAQ: http://laggron.red/warnsystem.html\n"
 "    "
 msgstr ""
 
-#: warnsystem/warnsystem.py:236 warnsystem/warnsystem.py:364
+#: warnsystem/warnsystem.py:166 warnsystem/warnsystem.py:284
 msgid ""
 "The reason is too long for an embed.\n"
 "\n"
@@ -1833,13 +1830,7 @@ msgid ""
 "<https://gist.github.com/>*"
 msgstr ""
 
-#: warnsystem/warnsystem.py:259 warnsystem/warnsystem.py:456
-msgid ""
-"You need to set up the mute role before doing this.\n"
-"Use the `[p]warnset mute` command for this."
-msgstr ""
-
-#: warnsystem/warnsystem.py:266 warnsystem/warnsystem.py:464
+#: warnsystem/warnsystem.py:199 warnsystem/warnsystem.py:378
 msgid ""
 "Please set up a modlog channel before warning a member.\n"
 "\n"
@@ -1850,26 +1841,11 @@ msgid ""
 "*Load the `modlogs` cog and use the `[p]modlogset modlog` command.*"
 msgstr ""
 
-#: warnsystem/warnsystem.py:277
-msgid ""
-"You are not allowed to do this, {member} is higher than you in the role hierarchy. You can only warn members which top role is lower than yours.\n"
-"\n"
-msgstr ""
-
-#: warnsystem/warnsystem.py:282
-msgid ""
-"You can disable this check by using the `[p]warnset hierarchy` command."
-msgstr ""
-
-#: warnsystem/warnsystem.py:288
+#: warnsystem/warnsystem.py:208
 msgid "Hackban failed: No user found."
 msgstr ""
 
-#: warnsystem/warnsystem.py:297 warnsystem/warnsystem.py:1273
-msgid "Done."
-msgstr ""
-
-#: warnsystem/warnsystem.py:331
+#: warnsystem/warnsystem.py:251
 msgid ""
 "Processing mass warning...\n"
 "{i}/{total} {members} warned ({percent}%)\n"
@@ -1880,33 +1856,33 @@ msgid ""
 "{tick5} Reason: {reason}"
 msgstr ""
 
-#: warnsystem/warnsystem.py:342 warnsystem/warnsystem.py:381
-#: warnsystem/warnsystem.py:478 warnsystem/warnsystem.py:486
+#: warnsystem/warnsystem.py:262 warnsystem/warnsystem.py:301
+#: warnsystem/warnsystem.py:392 warnsystem/warnsystem.py:400
 msgid "members"
 msgstr ""
 
-#: warnsystem/warnsystem.py:342 warnsystem/warnsystem.py:381
-#: warnsystem/warnsystem.py:478 warnsystem/warnsystem.py:486
+#: warnsystem/warnsystem.py:262 warnsystem/warnsystem.py:301
+#: warnsystem/warnsystem.py:392 warnsystem/warnsystem.py:400
 msgid "member"
 msgstr ""
 
-#: warnsystem/warnsystem.py:359
+#: warnsystem/warnsystem.py:279
 msgid "You can only use `--hackban-select` with a level 5 warn."
 msgstr ""
 
-#: warnsystem/warnsystem.py:379
+#: warnsystem/warnsystem.py:299
 msgid "{total} {members} ({percent}% of the server)"
 msgstr ""
 
-#: warnsystem/warnsystem.py:387
+#: warnsystem/warnsystem.py:307
 msgid "{total} {users} not in the server."
 msgstr ""
 
-#: warnsystem/warnsystem.py:389
+#: warnsystem/warnsystem.py:309
 msgid "users"
 msgstr ""
 
-#: warnsystem/warnsystem.py:394
+#: warnsystem/warnsystem.py:314
 msgid ""
 "You're about to set a level {level} warning on {target}.\n"
 "\n"
@@ -1918,29 +1894,29 @@ msgid ""
 "{warning}Continue?"
 msgstr ""
 
-#: warnsystem/warnsystem.py:411
+#: warnsystem/warnsystem.py:331
 msgid "Not set"
 msgstr ""
 
-#: warnsystem/warnsystem.py:412
+#: warnsystem/warnsystem.py:333
 msgid ""
 ":warning: You're about to warn a lot of members! Avoid doing this to prevent being rate limited by Discord, especially if you enabled DMs.\n"
 "\n"
 msgstr ""
 
-#: warnsystem/warnsystem.py:433
+#: warnsystem/warnsystem.py:355
 msgid "Mass warn cancelled."
 msgstr ""
 
-#: warnsystem/warnsystem.py:476
+#: warnsystem/warnsystem.py:390
 msgid "Done! {failed} {members} out of {total} couldn't be warned."
 msgstr ""
 
-#: warnsystem/warnsystem.py:484
+#: warnsystem/warnsystem.py:398
 msgid "Done! {total} {members} successfully warned."
 msgstr ""
 
-#: warnsystem/warnsystem.py:505
+#: warnsystem/warnsystem.py:419
 #, docstring
 msgid ""
 "\n"
@@ -1951,7 +1927,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:516
+#: warnsystem/warnsystem.py:430
 #, docstring
 msgid ""
 "\n"
@@ -1961,25 +1937,21 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:533
+#: warnsystem/warnsystem.py:447
 #, docstring
 msgid ""
 "\n"
-"        Mute the user in all channels, including voice channels.\n"
+"        Timeout the user in all channels, including voice channels.\n"
 "\n"
-"        This mute will use a role that will automatically be created, if it was not already done.\n"
-"        Feel free to edit the role's permissions and move it in the roles hierarchy.\n"
-"\n"
-"        You can set a timed mute by providing a valid time before the reason.\n"
+"        You can set a timeout by providing a valid time before the reason.\n"
 "\n"
 "        Examples:\n"
-"        - `[p]warn 2 @user 30m`: 30 minutes mute\n"
-"        - `[p]warn 2 @user 5h Spam`: 5 hours mute for the reason \"Spam\"\n"
-"        - `[p]warn 2 @user Advertising`: Infinite mute for the reason \"Advertising\"\n"
+"        - `[p]warn 2 @user 30m`: 30-minute timeout\n"
+"        - `[p]warn 2 @user 5h Spam`: 5-hour timeout for the reason \"Spam\"\n"
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:551
+#: warnsystem/warnsystem.py:467
 #, docstring
 msgid ""
 "\n"
@@ -1987,7 +1959,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:559
+#: warnsystem/warnsystem.py:481
 #, docstring
 msgid ""
 "\n"
@@ -1999,7 +1971,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:580
+#: warnsystem/warnsystem.py:502
 #, docstring
 msgid ""
 "\n"
@@ -2017,7 +1989,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:606
+#: warnsystem/warnsystem.py:528
 #, docstring
 msgid ""
 "\n"
@@ -2031,7 +2003,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:642
+#: warnsystem/warnsystem.py:564
 #, docstring
 msgid ""
 "\n"
@@ -2039,17 +2011,17 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:669
+#: warnsystem/warnsystem.py:591
 #, docstring
 msgid ""
 "\n"
-"        Perform a mass mute.\n"
+"        Perform a mass timeout.\n"
 "\n"
 "        You can provide a duration with the `--time` flag, the format is the same as the simple        level 2 warning.\n"
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:699
+#: warnsystem/warnsystem.py:621
 #, docstring
 msgid ""
 "\n"
@@ -2057,7 +2029,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:726
+#: warnsystem/warnsystem.py:648
 #, docstring
 msgid ""
 "\n"
@@ -2065,7 +2037,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:753
+#: warnsystem/warnsystem.py:675
 #, docstring
 msgid ""
 "\n"
@@ -2075,7 +2047,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:787
+#: warnsystem/warnsystem.py:711
 #, docstring
 msgid ""
 "\n"
@@ -2086,186 +2058,27 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:803
+#: warnsystem/warnsystem.py:727
 msgid "You are not allowed to see other's warnings!"
 msgstr ""
 
-#: warnsystem/warnsystem.py:807
+#: warnsystem/warnsystem.py:731
 msgid "That member was never warned."
 msgstr ""
 
-#: warnsystem/warnsystem.py:810
+#: warnsystem/warnsystem.py:734
 msgid "That case doesn't exist."
 msgstr ""
 
-#: warnsystem/warnsystem.py:815
-msgid "Warnings"
-msgstr ""
-
-#: warnsystem/warnsystem.py:816
-msgid "Mute"
-msgstr ""
-
-#: warnsystem/warnsystem.py:816
-msgid "Mutes"
-msgstr ""
-
-#: warnsystem/warnsystem.py:817
-msgid "Kick"
-msgstr ""
-
-#: warnsystem/warnsystem.py:817
-msgid "Kicks"
-msgstr ""
-
-#: warnsystem/warnsystem.py:818
-msgid "Softban"
-msgstr ""
-
-#: warnsystem/warnsystem.py:818
-msgid "Softbans"
-msgstr ""
-
-#: warnsystem/warnsystem.py:819
-msgid "Ban"
-msgstr ""
-
-#: warnsystem/warnsystem.py:819
-msgid "Bans"
-msgstr ""
-
-#: warnsystem/warnsystem.py:843
+#: warnsystem/warnsystem.py:752
 msgid "User modlog summary."
 msgstr ""
 
-#: warnsystem/warnsystem.py:846
+#: warnsystem/warnsystem.py:755
 msgid "Total number of warnings: "
 msgstr ""
 
-#: warnsystem/warnsystem.py:849
-msgid "{len} last warnings"
-msgstr ""
-
-#: warnsystem/warnsystem.py:851
-msgid "Last warning"
-msgstr ""
-
-#: warnsystem/warnsystem.py:855
-msgid "Click on the reactions to scroll through the warnings"
-msgstr ""
-
-#: warnsystem/warnsystem.py:866
-msgid "Case #{number} informations"
-msgstr ""
-
-#: warnsystem/warnsystem.py:870
-msgid "Level"
-msgstr ""
-
-#: warnsystem/warnsystem.py:877
-msgid ""
-"{duration}\n"
-"(Until {date})"
-msgstr ""
-
-#: warnsystem/warnsystem.py:979
-msgid ""
-"Case #{number} edition.\n"
-"\n"
-"**Please type the new reason to set**"
-msgstr ""
-
-#: warnsystem/warnsystem.py:982
-msgid "You have two minutes to type your text in the chat."
-msgstr ""
-
-#: warnsystem/warnsystem.py:994
-msgid "Case #{number} edition."
-msgstr ""
-
-#: warnsystem/warnsystem.py:995
-msgid "Old reason"
-msgstr ""
-
-#: warnsystem/warnsystem.py:996
-msgid "New reason"
-msgstr ""
-
-#: warnsystem/warnsystem.py:997
-msgid "Click on ✅ to confirm the changes."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1005 warnsystem/warnsystem.py:1128
-msgid "Question timed out."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1017
-msgid "The reason was successfully edited!\n"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1019
-msgid "*The modlog message couldn't be edited. Check your logs for details.*"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1023
-msgid "The reason was not edited."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1094
-msgid ""
-"Member {member}'s clearance. By selecting ❌ on the user modlog summary, you can remove all warnings given to {member}. __All levels and notes are affected.__\n"
-"**Click on the reaction to confirm the removal of the entire user's modlog. This cannot be undone.**"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1111
-msgid ""
-"Case #{number} deletion.\n"
-"**Click on the reaction to confirm your action.**"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1115
-msgid ""
-"\n"
-"Note: Deleting the case will also do the following:"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1117
-msgid ""
-"\n"
-"- unmute the member"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1119
-msgid ""
-"\n"
-"- add all roles back to the member"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1132
-msgid "Nothing was removed."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1139
-msgid "User modlog cleared."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1160
-msgid "Warning deleted by {author}"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1166
-msgid "Adding removed roles back after unmute."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1167 warnsystem/warnsystem.py:1170
-msgid "The case was successfully deleted!"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1169
-msgid "*The modlog message couldn't be deleted. Check your logs for details.*"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1176
+#: warnsystem/warnsystem.py:768
 #, docstring
 msgid ""
 "\n"
@@ -2273,11 +2086,11 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:1183
+#: warnsystem/warnsystem.py:775
 msgid "No warnings have been issued in this server yet."
 msgstr ""
 
-#: warnsystem/warnsystem.py:1186
+#: warnsystem/warnsystem.py:778
 msgid ""
 "--- Case {number} ---\n"
 "Member:    {member} (ID: {member.id})\n"
@@ -2287,56 +2100,17 @@ msgid ""
 "Date:      {time}\n"
 msgstr ""
 
-#: warnsystem/warnsystem.py:1196
+#: warnsystem/warnsystem.py:788
 msgid ""
 "Duration:  {duration}\n"
 "Until:     {until}\n"
 msgstr ""
 
-#: warnsystem/warnsystem.py:1209
+#: warnsystem/warnsystem.py:801
 msgid "{total} warnings. Page {i}/{pages}"
 msgstr ""
 
-#: warnsystem/warnsystem.py:1219
-#, docstring
-msgid ""
-"\n"
-"        Unmute a member muted with WarnSystem.\n"
-"\n"
-"        If the member's roles were removed, they will be granted back.\n"
-"\n"
-"        *wsunmute = WarnSystem unmute. Feel free to add an alias.*\n"
-"        "
-msgstr ""
-
-#: warnsystem/warnsystem.py:1229
-msgid "The mute role is not set or lost."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1232
-msgid "That member isn't muted."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1250
-msgid "[WarnSystem] Member unmuted by {author} (ID: {author.id})"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1256
-msgid "Member unmuted."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1259
-msgid "Member unmuted. {len_roles} roles to reassign..."
-msgstr ""
-
-#: warnsystem/warnsystem.py:1275
-msgid ""
-"\n"
-"\n"
-"Failed to add {fails}/{len_roles} roles back:\n"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1284
+#: warnsystem/warnsystem.py:812
 #, docstring
 msgid ""
 "\n"
@@ -2346,19 +2120,19 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:1292
+#: warnsystem/warnsystem.py:821
 msgid "That user is not banned."
 msgstr ""
 
-#: warnsystem/warnsystem.py:1297
+#: warnsystem/warnsystem.py:827
 msgid "Failed to unban the given member. Check your logs for details."
 msgstr ""
 
-#: warnsystem/warnsystem.py:1303
+#: warnsystem/warnsystem.py:836
 msgid "User unbanned."
 msgstr ""
 
-#: warnsystem/warnsystem.py:1307
+#: warnsystem/warnsystem.py:840
 #, docstring
 msgid ""
 "\n"
@@ -2366,7 +2140,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warnsystem/warnsystem.py:1311
+#: warnsystem/warnsystem.py:844
 msgid ""
 "Laggron's Dumb Cogs V3 - warnsystem\n"
 "\n"
@@ -2374,21 +2148,9 @@ msgid ""
 "Author: {0.__author__[0]}\n"
 "\n"
 "Github repository: https://github.com/retke/Laggrons-Dumb-Cogs/tree/v3\n"
-"Discord server: https://discord.gg/AVzjfpR\n"
+"Discord server: https://discord.gg/GET4DVk\n"
 "Documentation: http://laggrons-dumb-cogs.readthedocs.io/\n"
 "Help translating the cog: https://crowdin.com/project/laggrons-dumb-cogs/\n"
 "\n"
 "Support my work on Patreon: https://www.patreon.com/retke"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1370
-msgid ""
-"Updating channel settings so the mute role will work here. Disable the auto-"
-"update with [p]warnset autoupdate"
-msgstr ""
-
-#: warnsystem/warnsystem.py:1453
-msgid ""
-"I need the `Add reactions` and `Manage messages` in the current channel if "
-"you want to use this command."
 msgstr ""

--- a/warnsystem/paginator.py
+++ b/warnsystem/paginator.py
@@ -24,9 +24,7 @@ _PageSource = TypeVar("_PageSource", bound=menus.PageSource)
 
 
 class NumberedPageModal(discord.ui.Modal, title="Go to page"):
-    page = discord.ui.TextInput(
-        label="Page", placeholder="Enter a number", min_length=1
-    )
+    page = discord.ui.TextInput(label="Page", placeholder="Enter a number", min_length=1)
 
     def __init__(self, max_pages: Optional[int]) -> None:
         super().__init__()
@@ -42,12 +40,12 @@ class NumberedPageModal(discord.ui.Modal, title="Go to page"):
 
 class Pages(discord.ui.View, Generic[_PageSource]):
     def __init__(
-            self,
-            source: _PageSource,
-            *,
-            ctx: "Context",
-            check_embeds: bool = False,
-            compact: bool = False,
+        self,
+        source: _PageSource,
+        *,
+        ctx: "Context",
+        check_embeds: bool = False,
+        compact: bool = False,
     ):
         super().__init__()
         self.source: _PageSource = source
@@ -93,18 +91,14 @@ class Pages(discord.ui.View, Generic[_PageSource]):
         else:
             return None
 
-    async def show_page(
-            self, interaction: discord.Interaction, page_number: int
-    ) -> None:
+    async def show_page(self, interaction: discord.Interaction, page_number: int) -> None:
         page = await self.source.get_page(page_number)
         self.current_page = page_number
         kwargs = await self._get_kwargs_from_page(page)
         self._update_labels(page_number)
         if kwargs is not None:
             if interaction.response.is_done():
-                await interaction.followup.edit_message(
-                    "@original", **kwargs, view=self
-                )
+                await interaction.followup.edit_message("@original", **kwargs, view=self)
             else:
                 await interaction.response.edit_message(**kwargs, view=self)
 
@@ -112,11 +106,9 @@ class Pages(discord.ui.View, Generic[_PageSource]):
         self.go_to_first_page.disabled = page_number == 0
         if self.compact:
             max_pages = self.source.get_max_pages()
-            self.go_to_last_page.disabled = (
-                    max_pages is None or (page_number + 1) >= max_pages
-            )
+            self.go_to_last_page.disabled = max_pages is None or (page_number + 1) >= max_pages
             self.go_to_next_page.disabled = (
-                    max_pages is not None and (page_number + 1) >= max_pages
+                max_pages is not None and (page_number + 1) >= max_pages
             )
             self.go_to_previous_page.disabled = page_number == 0
             return
@@ -138,9 +130,7 @@ class Pages(discord.ui.View, Generic[_PageSource]):
                 self.go_to_previous_page.disabled = True
                 self.go_to_previous_page.label = "…"
 
-    async def show_checked_page(
-            self, interaction: discord.Interaction, page_number: int
-    ) -> None:
+    async def show_checked_page(self, interaction: discord.Interaction, page_number: int) -> None:
         max_pages = self.source.get_max_pages()
         try:
             if max_pages is None:
@@ -154,8 +144,8 @@ class Pages(discord.ui.View, Generic[_PageSource]):
 
     async def interaction_check(self, interaction: discord.Interaction["Red"]) -> bool:
         if interaction.user and interaction.user.id in (
-                self.bot.owner_id,
-                self.ctx.author.id,
+            self.bot.owner_id,
+            self.ctx.author.id,
         ):
             return True
         await interaction.response.send_message(
@@ -173,28 +163,26 @@ class Pages(discord.ui.View, Generic[_PageSource]):
             pass
 
     async def on_error(
-            self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item
+        self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item
     ) -> None:
         log.error("Error on pagination", exc_info=error)
         if interaction.response.is_done():
-            await interaction.followup.send(
-                "An unknown error occurred, sorry", ephemeral=True
-            )
+            await interaction.followup.send("An unknown error occurred, sorry", ephemeral=True)
         else:
             await interaction.response.send_message(
                 "An unknown error occurred, sorry", ephemeral=True
             )
 
     async def start(
-            self,
-            *,
-            content: Optional[str] = None,
-            embed: Optional[discord.Embed],
-            ephemeral: bool = False,
+        self,
+        *,
+        content: Optional[str] = None,
+        embed: Optional[discord.Embed],
+        ephemeral: bool = False,
     ) -> None:
         if (
-                self.check_embeds
-                and not self.ctx.channel.permissions_for(self.ctx.guild.me).embed_links
+            self.check_embeds
+            and not self.ctx.channel.permissions_for(self.ctx.guild.me).embed_links
         ):
             await self.ctx.send(
                 "Bot does not have embed links permission in this channel.",
@@ -214,44 +202,36 @@ class Pages(discord.ui.View, Generic[_PageSource]):
         self.message = await self.ctx.send(**kwargs, view=self, ephemeral=ephemeral)
 
     @discord.ui.button(label="≪", style=discord.ButtonStyle.grey)
-    async def go_to_first_page(
-            self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
+    async def go_to_first_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         """go to the first page"""
         await self.show_page(interaction, 0)
 
     @discord.ui.button(label="Back", style=discord.ButtonStyle.blurple)
     async def go_to_previous_page(
-            self, interaction: discord.Interaction, button: discord.ui.Button
+        self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         """go to the previous page"""
         await self.show_checked_page(interaction, self.current_page - 1)
 
     @discord.ui.button(label="Current", style=discord.ButtonStyle.grey, disabled=True)
     async def go_to_current_page(
-            self, interaction: discord.Interaction, button: discord.ui.Button
+        self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         pass
 
     @discord.ui.button(label="Next", style=discord.ButtonStyle.blurple)
-    async def go_to_next_page(
-            self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
+    async def go_to_next_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         """go to the next page"""
         await self.show_checked_page(interaction, self.current_page + 1)
 
     @discord.ui.button(label="≫", style=discord.ButtonStyle.grey)
-    async def go_to_last_page(
-            self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
+    async def go_to_last_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         """go to the last page"""
         # The call here is safe because it's guarded by skip_if
         await self.show_page(interaction, self.source.get_max_pages() - 1)  # type: ignore
 
     @discord.ui.button(label="Skip to page...", style=discord.ButtonStyle.grey)
-    async def numbered_page(
-            self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
+    async def numbered_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         """lets you type a page number to go to"""
 
         modal = NumberedPageModal(self.source.get_max_pages())
@@ -262,9 +242,7 @@ class Pages(discord.ui.View, Generic[_PageSource]):
             await interaction.followup.send("Took too long", ephemeral=True)
             return
         elif self.is_finished():
-            await modal.interaction.response.send_message(
-                "Took too long", ephemeral=True
-            )
+            await modal.interaction.response.send_message("Took too long", ephemeral=True)
             return
 
         value = str(modal.page.value)
@@ -281,9 +259,7 @@ class Pages(discord.ui.View, Generic[_PageSource]):
             await modal.interaction.response.send_message(error, ephemeral=True)
 
     @discord.ui.button(label="Quit", style=discord.ButtonStyle.red)
-    async def stop_pages(
-            self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
+    async def stop_pages(self, interaction: discord.Interaction, button: discord.ui.Button):
         """stops the pagination session."""
         for item in self.children:
             item.disabled = True
@@ -295,21 +271,19 @@ class FieldPageSource(menus.ListPageSource):
     """A page source that requires (field_name, field_value) tuple items."""
 
     def __init__(
-            self,
-            entries: list[tuple[Any, Any]],
-            *,
-            per_page: int = 12,
-            inline: bool = False,
-            clear_description: bool = True,
+        self,
+        entries: list[tuple[Any, Any]],
+        *,
+        per_page: int = 12,
+        inline: bool = False,
+        clear_description: bool = True,
     ) -> None:
         super().__init__(entries, per_page=per_page)
         self.embed: discord.Embed = discord.Embed(colour=discord.Colour.blurple())
         self.clear_description: bool = clear_description
         self.inline: bool = inline
 
-    async def format_page(
-            self, menu: Pages, entries: list[tuple[Any, Any]]
-    ) -> discord.Embed:
+    async def format_page(self, menu: Pages, entries: list[tuple[Any, Any]]) -> discord.Embed:
         self.embed.clear_fields()
         if self.clear_description:
             self.embed.description = None
@@ -319,9 +293,7 @@ class FieldPageSource(menus.ListPageSource):
 
         maximum = self.get_max_pages()
         if maximum > 1:
-            text = (
-                f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
-            )
+            text = f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
             self.embed.set_footer(text=text)
 
         return self.embed
@@ -350,9 +322,7 @@ class SimplePageSource(menus.ListPageSource):
 
         maximum = self.get_max_pages()
         if maximum > 1:
-            footer = (
-                f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
-            )
+            footer = f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
             menu.embed.set_footer(text=footer)
 
         menu.embed.description = "\n".join(pages)
@@ -365,10 +335,6 @@ class SimplePages(Pages):
     Basically an embed with some normal formatting.
     """
 
-    def __init__(
-            self, entries, *, interaction: discord.Interaction, per_page: int = 12
-    ):
-        super().__init__(
-            SimplePageSource(entries, per_page=per_page), interaction=interaction
-        )
+    def __init__(self, entries, *, interaction: discord.Interaction, per_page: int = 12):
+        super().__init__(SimplePageSource(entries, per_page=per_page), interaction=interaction)
         self.embed = discord.Embed(colour=discord.Colour.blurple())

--- a/warnsystem/paginator.py
+++ b/warnsystem/paginator.py
@@ -24,7 +24,9 @@ _PageSource = TypeVar("_PageSource", bound=menus.PageSource)
 
 
 class NumberedPageModal(discord.ui.Modal, title="Go to page"):
-    page = discord.ui.TextInput(label="Page", placeholder="Enter a number", min_length=1)
+    page = discord.ui.TextInput(
+        label="Page", placeholder="Enter a number", min_length=1
+    )
 
     def __init__(self, max_pages: Optional[int]) -> None:
         super().__init__()
@@ -40,12 +42,12 @@ class NumberedPageModal(discord.ui.Modal, title="Go to page"):
 
 class Pages(discord.ui.View, Generic[_PageSource]):
     def __init__(
-        self,
-        source: _PageSource,
-        *,
-        ctx: "Context",
-        check_embeds: bool = False,
-        compact: bool = False,
+            self,
+            source: _PageSource,
+            *,
+            ctx: "Context",
+            check_embeds: bool = False,
+            compact: bool = False,
     ):
         super().__init__()
         self.source: _PageSource = source
@@ -91,14 +93,18 @@ class Pages(discord.ui.View, Generic[_PageSource]):
         else:
             return None
 
-    async def show_page(self, interaction: discord.Interaction, page_number: int) -> None:
+    async def show_page(
+            self, interaction: discord.Interaction, page_number: int
+    ) -> None:
         page = await self.source.get_page(page_number)
         self.current_page = page_number
         kwargs = await self._get_kwargs_from_page(page)
         self._update_labels(page_number)
         if kwargs is not None:
             if interaction.response.is_done():
-                await interaction.followup.edit_message("@original", **kwargs, view=self)
+                await interaction.followup.edit_message(
+                    "@original", **kwargs, view=self
+                )
             else:
                 await interaction.response.edit_message(**kwargs, view=self)
 
@@ -106,9 +112,11 @@ class Pages(discord.ui.View, Generic[_PageSource]):
         self.go_to_first_page.disabled = page_number == 0
         if self.compact:
             max_pages = self.source.get_max_pages()
-            self.go_to_last_page.disabled = max_pages is None or (page_number + 1) >= max_pages
+            self.go_to_last_page.disabled = (
+                    max_pages is None or (page_number + 1) >= max_pages
+            )
             self.go_to_next_page.disabled = (
-                max_pages is not None and (page_number + 1) >= max_pages
+                    max_pages is not None and (page_number + 1) >= max_pages
             )
             self.go_to_previous_page.disabled = page_number == 0
             return
@@ -130,7 +138,9 @@ class Pages(discord.ui.View, Generic[_PageSource]):
                 self.go_to_previous_page.disabled = True
                 self.go_to_previous_page.label = "…"
 
-    async def show_checked_page(self, interaction: discord.Interaction, page_number: int) -> None:
+    async def show_checked_page(
+            self, interaction: discord.Interaction, page_number: int
+    ) -> None:
         max_pages = self.source.get_max_pages()
         try:
             if max_pages is None:
@@ -144,8 +154,8 @@ class Pages(discord.ui.View, Generic[_PageSource]):
 
     async def interaction_check(self, interaction: discord.Interaction["Red"]) -> bool:
         if interaction.user and interaction.user.id in (
-            self.bot.owner_id,
-            self.ctx.author.id,
+                self.bot.owner_id,
+                self.ctx.author.id,
         ):
             return True
         await interaction.response.send_message(
@@ -163,29 +173,32 @@ class Pages(discord.ui.View, Generic[_PageSource]):
             pass
 
     async def on_error(
-        self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item
+            self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item
     ) -> None:
         log.error("Error on pagination", exc_info=error)
         if interaction.response.is_done():
-            await interaction.followup.send("An unknown error occurred, sorry", ephemeral=True)
+            await interaction.followup.send(
+                "An unknown error occurred, sorry", ephemeral=True
+            )
         else:
             await interaction.response.send_message(
                 "An unknown error occurred, sorry", ephemeral=True
             )
 
     async def start(
-        self,
-        *,
-        content: Optional[str] = None,
-        embed: Optional[discord.Embed],
-        ephemeral: bool = False,
+            self,
+            *,
+            content: Optional[str] = None,
+            embed: Optional[discord.Embed],
+            ephemeral: bool = False,
     ) -> None:
         if (
-            self.check_embeds
-            and not self.ctx.channel.permissions_for(self.ctx.guild.me).embed_links
+                self.check_embeds
+                and not self.ctx.channel.permissions_for(self.ctx.guild.me).embed_links
         ):
             await self.ctx.send(
-                "Bot does not have embed links permission in this channel.", ephemeral=True
+                "Bot does not have embed links permission in this channel.",
+                ephemeral=True,
             )
             return
 
@@ -201,36 +214,44 @@ class Pages(discord.ui.View, Generic[_PageSource]):
         self.message = await self.ctx.send(**kwargs, view=self, ephemeral=ephemeral)
 
     @discord.ui.button(label="≪", style=discord.ButtonStyle.grey)
-    async def go_to_first_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def go_to_first_page(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         """go to the first page"""
         await self.show_page(interaction, 0)
 
     @discord.ui.button(label="Back", style=discord.ButtonStyle.blurple)
     async def go_to_previous_page(
-        self, interaction: discord.Interaction, button: discord.ui.Button
+            self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         """go to the previous page"""
         await self.show_checked_page(interaction, self.current_page - 1)
 
     @discord.ui.button(label="Current", style=discord.ButtonStyle.grey, disabled=True)
     async def go_to_current_page(
-        self, interaction: discord.Interaction, button: discord.ui.Button
+            self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         pass
 
     @discord.ui.button(label="Next", style=discord.ButtonStyle.blurple)
-    async def go_to_next_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def go_to_next_page(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         """go to the next page"""
         await self.show_checked_page(interaction, self.current_page + 1)
 
     @discord.ui.button(label="≫", style=discord.ButtonStyle.grey)
-    async def go_to_last_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def go_to_last_page(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         """go to the last page"""
         # The call here is safe because it's guarded by skip_if
         await self.show_page(interaction, self.source.get_max_pages() - 1)  # type: ignore
 
     @discord.ui.button(label="Skip to page...", style=discord.ButtonStyle.grey)
-    async def numbered_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def numbered_page(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         """lets you type a page number to go to"""
 
         modal = NumberedPageModal(self.source.get_max_pages())
@@ -241,7 +262,9 @@ class Pages(discord.ui.View, Generic[_PageSource]):
             await interaction.followup.send("Took too long", ephemeral=True)
             return
         elif self.is_finished():
-            await modal.interaction.response.send_message("Took too long", ephemeral=True)
+            await modal.interaction.response.send_message(
+                "Took too long", ephemeral=True
+            )
             return
 
         value = str(modal.page.value)
@@ -258,7 +281,9 @@ class Pages(discord.ui.View, Generic[_PageSource]):
             await modal.interaction.response.send_message(error, ephemeral=True)
 
     @discord.ui.button(label="Quit", style=discord.ButtonStyle.red)
-    async def stop_pages(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def stop_pages(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         """stops the pagination session."""
         for item in self.children:
             item.disabled = True
@@ -270,19 +295,21 @@ class FieldPageSource(menus.ListPageSource):
     """A page source that requires (field_name, field_value) tuple items."""
 
     def __init__(
-        self,
-        entries: list[tuple[Any, Any]],
-        *,
-        per_page: int = 12,
-        inline: bool = False,
-        clear_description: bool = True,
+            self,
+            entries: list[tuple[Any, Any]],
+            *,
+            per_page: int = 12,
+            inline: bool = False,
+            clear_description: bool = True,
     ) -> None:
         super().__init__(entries, per_page=per_page)
         self.embed: discord.Embed = discord.Embed(colour=discord.Colour.blurple())
         self.clear_description: bool = clear_description
         self.inline: bool = inline
 
-    async def format_page(self, menu: Pages, entries: list[tuple[Any, Any]]) -> discord.Embed:
+    async def format_page(
+            self, menu: Pages, entries: list[tuple[Any, Any]]
+    ) -> discord.Embed:
         self.embed.clear_fields()
         if self.clear_description:
             self.embed.description = None
@@ -292,7 +319,9 @@ class FieldPageSource(menus.ListPageSource):
 
         maximum = self.get_max_pages()
         if maximum > 1:
-            text = f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
+            text = (
+                f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
+            )
             self.embed.set_footer(text=text)
 
         return self.embed
@@ -321,7 +350,9 @@ class SimplePageSource(menus.ListPageSource):
 
         maximum = self.get_max_pages()
         if maximum > 1:
-            footer = f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
+            footer = (
+                f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
+            )
             menu.embed.set_footer(text=footer)
 
         menu.embed.description = "\n".join(pages)
@@ -334,6 +365,10 @@ class SimplePages(Pages):
     Basically an embed with some normal formatting.
     """
 
-    def __init__(self, entries, *, interaction: discord.Interaction, per_page: int = 12):
-        super().__init__(SimplePageSource(entries, per_page=per_page), interaction=interaction)
+    def __init__(
+            self, entries, *, interaction: discord.Interaction, per_page: int = 12
+    ):
+        super().__init__(
+            SimplePageSource(entries, per_page=per_page), interaction=interaction
+        )
         self.embed = discord.Embed(colour=discord.Colour.blurple())

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -70,11 +70,7 @@ class SettingsMixin(MixinMeta):
             )
             return
         if not 0 <= days <= 7:
-            is_ban = (
-                _("You can set 0 to disable messages deletion.")
-                if ban_type == "ban"
-                else ""
-            )
+            is_ban = _("You can set 0 to disable messages deletion.") if ban_type == "ban" else ""
             await ctx.send(
                 _(
                     "The number of days of messages to delete must be between "
@@ -99,7 +95,7 @@ class SettingsMixin(MixinMeta):
 
     @warnset.command(name="channel")
     async def warnset_channel(
-            self, ctx: commands.Context, channel: discord.TextChannel, level: int = None
+        self, ctx: commands.Context, channel: discord.TextChannel, level: int = None
     ):
         """
         Set the channel for the WarnSystem modlog.
@@ -114,13 +110,9 @@ class SettingsMixin(MixinMeta):
         """
         guild = ctx.guild
         if not channel.permissions_for(guild.me).send_messages:
-            await ctx.send(
-                _("I don't have the permission to send messages in that channel.")
-            )
+            await ctx.send(_("I don't have the permission to send messages in that channel."))
         elif not channel.permissions_for(guild.me).embed_links:
-            await ctx.send(
-                _("I don't have the permissions to send embed links in that channel.")
-            )
+            await ctx.send(_("I don't have the permissions to send embed links in that channel."))
         else:
             if not level:
                 await self.data.guild(guild).channels.main.set(channel.id)
@@ -148,9 +140,7 @@ class SettingsMixin(MixinMeta):
                 )
 
     @warnset.command("color")
-    async def warnset_color(
-            self, ctx: commands.Context, level: int, color: discord.Color
-    ):
+    async def warnset_color(self, ctx: commands.Context, level: int, color: discord.Color):
         """
         Edit the color of the embed.
 
@@ -203,12 +193,8 @@ class SettingsMixin(MixinMeta):
             for member, logs in data.items():
                 cases = []
                 for case in [y for x, y in logs.items() if x.startswith("case")]:
-                    level = {"Simple": 1, "Kick": 3, "Softban": 4, "Ban": 5}.get(
-                        case["level"], 1
-                    )
-                    timestamp = datetime.strptime(
-                        case["timestamp"], "%d %b %Y %H:%M"
-                    ).timestamp()
+                    level = {"Simple": 1, "Kick": 3, "Softban": 4, "Ban": 5}.get(case["level"], 1)
+                    timestamp = datetime.strptime(case["timestamp"], "%d %b %Y %H:%M").timestamp()
                     cases.append(
                         {
                             "level": level,
@@ -219,9 +205,7 @@ class SettingsMixin(MixinMeta):
                         }
                     )
                     total_cases += 1
-                async with self.data.custom(
-                        "MODLOGS", guild.id, int(member)
-                ).x() as logs:
+                async with self.data.custom("MODLOGS", guild.id, int(member)).x() as logs:
                     logs.extend(cases)
             return total_cases
 
@@ -300,9 +284,7 @@ class SettingsMixin(MixinMeta):
             await ctx.send(_("Starting conversion... This might take a long time."))
             total = await convert(content)
         elif pred.result == 1:
-            await ctx.send(
-                _("Deleting server logs... Settings, such as channels, are kept.")
-            )
+            await ctx.send(_("Deleting server logs... Settings, such as channels, are kept."))
             await self.data.custom("MODLOGS").set({})
             await ctx.send(_("Starting conversion... This might take a long time."))
             total = await convert(content)
@@ -322,7 +304,7 @@ class SettingsMixin(MixinMeta):
 
     @warnset.command(name="description")
     async def warnset_description(
-            self, ctx: commands.Context, level: int, destination: str, *, description: str
+        self, ctx: commands.Context, level: int, destination: str, *, description: str
     ):
         """
         Set a custom description for the modlog embeds.
@@ -375,9 +357,7 @@ class SettingsMixin(MixinMeta):
             "embed_description_" + destination, str(level), value=description
         )
         await ctx.send(
-            _(
-                "The new description for {destination} (warn {level}) was successfully set!"
-            ).format(
+            _("The new description for {destination} (warn {level}) was successfully set!").format(
                 destination=_("modlog") if destination == "modlog" else _("user"),
                 level=level,
             )
@@ -409,9 +389,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
             )
         elif enable:
             await self.data.guild(guild).log_manual.set(True)
-            await ctx.send(
-                _("Done. The bot will now listen for manual actions and log them.")
-            )
+            await ctx.send(_("Done. The bot will now listen for manual actions and log them."))
         else:
             await self.data.guild(guild).log_manual.set(False)
             await ctx.send(_("Done. The bot won't listen for manual actions anymore."))
@@ -473,9 +451,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
                 _(
                     "The bot {respect} reinvite unbanned members. If you want to "
                     "change this, type `[p]warnset reinvite {opposite}`."
-                ).format(
-                    respect=_("does") if current else _("doesn't"), opposite=not current
-                )
+                ).format(respect=_("does") if current else _("doesn't"), opposite=not current)
             )
         elif enable:
             await self.data.guild(guild).reinvite.set(True)
@@ -509,16 +485,12 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
                 if not channel:
                     if key != "main":
                         continue
-                    channel = _("Not set. Use `{prefix}warnset channel`").format(
-                        prefix=ctx.prefix
-                    )
+                    channel = _("Not set. Use `{prefix}warnset channel`").format(prefix=ctx.prefix)
                 else:
                     channel = guild.get_channel(channel)
                     channel = channel.mention if channel else _("Not found")
                 if key == "main":
-                    channels += _("Default channel: {channel}\n").format(
-                        channel=channel
-                    )
+                    channels += _("Default channel: {channel}\n").format(channel=channel)
                 else:
                     channels += _("Level {level} warnings channel: {channel}\n").format(
                         channel=channel, level=key
@@ -613,9 +585,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
                 inline=False,
             )
         try:
-            await menus.menu(
-                ctx=ctx, pages=embeds, controls=menus.DEFAULT_CONTROLS, timeout=90
-            )
+            await menus.menu(ctx=ctx, pages=embeds, controls=menus.DEFAULT_CONTROLS, timeout=90)
         except discord.errors.HTTPException as e:
             log.error("Couldn't make embed for displaying settings.", exc_info=e)
             await ctx.send(
@@ -641,9 +611,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
                 _(
                     "The bot {respect} show the responsible moderator to the warned member in DM. "
                     "If you want to change this, type `[p]warnset showmod {opposite}`."
-                ).format(
-                    respect=_("does") if current else _("doesn't"), opposite=not current
-                )
+                ).format(respect=_("does") if current else _("doesn't"), opposite=not current)
             )
         elif enable:
             await self.data.guild(guild).show_mod.set(True)
@@ -655,9 +623,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
             )
         else:
             await self.data.guild(guild).show_mod.set(False)
-            await ctx.send(
-                _("Done. The bot will no longer show the responsible moderator.")
-            )
+            await ctx.send(_("Done. The bot will no longer show the responsible moderator."))
 
     @warnset.group(name="substitutions")
     async def warnset_substitutions(self, ctx: commands.Context):
@@ -675,9 +641,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
         pass
 
     @warnset_substitutions.command(name="add")
-    async def warnset_substitutions_add(
-            self, ctx: commands.Context, name: str, *, text: str
-    ):
+    async def warnset_substitutions_add(self, ctx: commands.Context, name: str, *, text: str):
         """
         Create a new subsitution.
 
@@ -699,9 +663,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
                 )
                 return
             if len(text) > 600:
-                await ctx.send(
-                    _("That substitution is too long! Maximum is 600 characters!")
-                )
+                await ctx.send(_("That substitution is too long! Maximum is 600 characters!"))
                 return
             substitutions[name] = text
         await ctx.send(
@@ -761,9 +723,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
             )
 
     @warnset.command(name="thumbnail")
-    async def warnset_thumbnail(
-            self, ctx: commands.Context, level: int, url: str = None
-    ):
+    async def warnset_thumbnail(self, ctx: commands.Context, level: int, url: str = None):
         """
         Edit the image displayed on the embeds.
 
@@ -777,7 +737,7 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
             return
         await self.data.guild(guild).thumbnails.set_raw(str(level), value=url)
         await ctx.send(
-            _(
-                "The new image for level {level} warnings has been set to {image}."
-            ).format(level=level, image=url)
+            _("The new image for level {level} warnings has been set to {image}.").format(
+                level=level, image=url
+            )
         )

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -38,41 +38,6 @@ class SettingsMixin(MixinMeta):
         pass
 
     # commands are listed in the alphabetic order, like the help message
-    @warnset.command(name="autoupdate")
-    async def warnset_autoupdate(self, ctx: commands.Context, enable: bool = None):
-        """
-        Defines if the bot should update permissions of new channels for the mute role.
-
-        If enabled, for each new text channel and category created, the Mute role will be\
-        denied the permission to send messages and add reactions here.
-        Keeping this disabled might cause issues with channels created after the WarnSystem setup\
-        where muted members can talk.
-        """
-        guild = ctx.guild
-        current = await self.data.guild(guild).update_mute()
-        if enable is None:
-            await ctx.send(
-                _(
-                    "The bot currently {update} new channels. If you want to change this, "
-                    "type `[p]warnset autoupdate {opposite}`."
-                ).format(
-                    update=_("updates") if current else _("doesn't update"), opposite=not current
-                )
-            )
-        elif enable:
-            await self.data.guild(guild).update_mute.set(True)
-            await ctx.send(
-                _("Done. New created channels will be updated to keep the mute role working.")
-            )
-        else:
-            await self.data.guild(guild).update_mute.set(False)
-            await ctx.send(
-                _(
-                    "Done. New created channels won't be updated.\n**Make sure to update "
-                    "manually new channels to keep the mute role working as intended.**"
-                )
-            )
-
     @warnset.command("bandays")
     async def warnset_bandays(self, ctx: commands.Context, ban_type: str, days: int):
         """
@@ -105,7 +70,11 @@ class SettingsMixin(MixinMeta):
             )
             return
         if not 0 <= days <= 7:
-            is_ban = _("You can set 0 to disable messages deletion.") if ban_type == "ban" else ""
+            is_ban = (
+                _("You can set 0 to disable messages deletion.")
+                if ban_type == "ban"
+                else ""
+            )
             await ctx.send(
                 _(
                     "The number of days of messages to delete must be between "
@@ -130,7 +99,7 @@ class SettingsMixin(MixinMeta):
 
     @warnset.command(name="channel")
     async def warnset_channel(
-        self, ctx: commands.Context, channel: discord.TextChannel, level: int = None
+            self, ctx: commands.Context, channel: discord.TextChannel, level: int = None
     ):
         """
         Set the channel for the WarnSystem modlog.
@@ -145,9 +114,13 @@ class SettingsMixin(MixinMeta):
         """
         guild = ctx.guild
         if not channel.permissions_for(guild.me).send_messages:
-            await ctx.send(_("I don't have the permission to send messages in that channel."))
+            await ctx.send(
+                _("I don't have the permission to send messages in that channel.")
+            )
         elif not channel.permissions_for(guild.me).embed_links:
-            await ctx.send(_("I don't have the permissions to send embed links in that channel."))
+            await ctx.send(
+                _("I don't have the permissions to send embed links in that channel.")
+            )
         else:
             if not level:
                 await self.data.guild(guild).channels.main.set(channel.id)
@@ -175,7 +148,9 @@ class SettingsMixin(MixinMeta):
                 )
 
     @warnset.command("color")
-    async def warnset_color(self, ctx: commands.Context, level: int, color: discord.Color):
+    async def warnset_color(
+            self, ctx: commands.Context, level: int, color: discord.Color
+    ):
         """
         Edit the color of the embed.
 
@@ -228,8 +203,12 @@ class SettingsMixin(MixinMeta):
             for member, logs in data.items():
                 cases = []
                 for case in [y for x, y in logs.items() if x.startswith("case")]:
-                    level = {"Simple": 1, "Kick": 3, "Softban": 4, "Ban": 5}.get(case["level"], 1)
-                    timestamp = datetime.strptime(case["timestamp"], "%d %b %Y %H:%M").timestamp()
+                    level = {"Simple": 1, "Kick": 3, "Softban": 4, "Ban": 5}.get(
+                        case["level"], 1
+                    )
+                    timestamp = datetime.strptime(
+                        case["timestamp"], "%d %b %Y %H:%M"
+                    ).timestamp()
                     cases.append(
                         {
                             "level": level,
@@ -241,7 +220,9 @@ class SettingsMixin(MixinMeta):
                         }
                     )
                     total_cases += 1
-                async with self.data.custom("MODLOGS", guild.id, int(member)).x() as logs:
+                async with self.data.custom(
+                        "MODLOGS", guild.id, int(member)
+                ).x() as logs:
                     logs.extend(cases)
             return total_cases
 
@@ -320,7 +301,9 @@ class SettingsMixin(MixinMeta):
             await ctx.send(_("Starting conversion... This might take a long time."))
             total = await convert(content)
         elif pred.result == 1:
-            await ctx.send(_("Deleting server logs... Settings, such as channels, are kept."))
+            await ctx.send(
+                _("Deleting server logs... Settings, such as channels, are kept.")
+            )
             await self.data.custom("MODLOGS").set({})
             await ctx.send(_("Starting conversion... This might take a long time."))
             total = await convert(content)
@@ -340,7 +323,7 @@ class SettingsMixin(MixinMeta):
 
     @warnset.command(name="description")
     async def warnset_description(
-        self, ctx: commands.Context, level: int, destination: str, *, description: str
+            self, ctx: commands.Context, level: int, destination: str, *, description: str
     ):
         """
         Set a custom description for the modlog embeds.
@@ -357,7 +340,7 @@ class SettingsMixin(MixinMeta):
         `{member.mention}` for a mention)
         - `{mod}`: The moderator that warned the member (you can also use keys like\
         `{moderator.id}`)
-        - `{duration}`: The duration of a timed mute/ban if it exists
+        - `{duration}`: The duration of a timed timeout/ban if it exists
         - `{time}`: The current date and time.
 
         __Examples:__
@@ -393,8 +376,11 @@ class SettingsMixin(MixinMeta):
             "embed_description_" + destination, str(level), value=description
         )
         await ctx.send(
-            _("The new description for {destination} (warn {level}) was successfully set!").format(
-                destination=_("modlog") if destination == "modlog" else _("user"), level=level
+            _(
+                "The new description for {destination} (warn {level}) was successfully set!"
+            ).format(
+                destination=_("modlog") if destination == "modlog" else _("user"),
+                level=level,
             )
         )
 
@@ -424,7 +410,9 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
             )
         elif enable:
             await self.data.guild(guild).log_manual.set(True)
-            await ctx.send(_("Done. The bot will now listen for manual actions and log them."))
+            await ctx.send(
+                _("Done. The bot will now listen for manual actions and log them.")
+            )
         else:
             await self.data.guild(guild).log_manual.set(False)
             await ctx.send(_("Done. The bot won't listen for manual actions anymore."))
@@ -469,168 +457,6 @@ save it, as if it was performed with WarnSystem. **However, the member will not 
                 )
             )
 
-    @warnset.command(name="mute")
-    async def warnset_mute(self, ctx: commands.Context, *, role: discord.Role = None):
-        """
-        Create the role used for muting members.
-
-        You can specify a role when invoking the command to specify which role should be used.
-        If you don't specify a role, one will be created for you.
-        """
-        guild = ctx.guild
-        my_position = guild.me.top_role.position
-        if not role:
-            if not guild.me.guild_permissions.manage_roles:
-                await ctx.send(
-                    _("I can't manage roles, please give me this permission to continue.")
-                )
-                return
-            async with ctx.typing():
-                fails = await self.api.maybe_create_mute_role(guild)
-                my_position = guild.me.top_role.position
-                if fails is False:
-                    await ctx.send(
-                        _(
-                            "A mute role was already created! You can change it by specifying "
-                            "a role when typing the command.\n`[p]warnset mute <role name>`"
-                        )
-                    )
-                    return
-                else:
-                    if fails:
-                        errors = _(
-                            "\n\nSome errors occured when editing the channel permissions:\n"
-                        ) + "\n".join(fails)
-                    else:
-                        errors = ""
-                    text = (
-                        _(
-                            "The role `Muted` was successfully created at position {pos}. Feel "
-                            "free to drag it in the hierarchy and edit its permissions, as long "
-                            "as my top role is above and the members to mute are below."
-                        ).format(pos=my_position - 1)
-                        + errors
-                    )
-                    for page in pagify(text):
-                        await ctx.send(page)
-        elif role.position >= my_position:
-            await ctx.send(
-                _(
-                    "That role is higher than my top role in the hierarchy. "
-                    'Please move it below "{bot_role}".'
-                ).format(bot_role=guild.me.top_role.name)
-            )
-        else:
-            await self.cache.update_mute_role(guild, role)
-            await ctx.send(_("The new mute role was successfully set!"))
-
-    @warnset.command(name="refreshmuterole")
-    @commands.cooldown(1, 120, commands.BucketType.guild)
-    async def warnset_refreshmuterole(self, ctx: commands.Context):
-        """
-        Refresh the mute role's permissions in the server.
-
-        This will iterate all of your channels and make sure all permissions are correctly\
-configured for the mute role.
-
-        The muted role will be prevented from sending messages and adding reactions in all text\
-channels, and prevented from talking in all voice channels.
-        """
-        guild = ctx.guild
-        mute_role = await self.cache.get_mute_role(guild)
-        if mute_role is None:
-            await ctx.send(
-                _(
-                    "No mute role configured on this server. "
-                    "Create one with `{prefix}warnset mute`."
-                ).format(prefix=ctx.clean_prefix)
-            )
-            return
-        mute_role = guild.get_role(mute_role)
-        if not mute_role:
-            await ctx.send(
-                _(
-                    "It looks like the configured mute role was deleted. "
-                    "Create a new one with `{prefix}warnset mute`."
-                ).format(prefix=ctx.clean_prefix)
-            )
-            return
-        if not guild.me.guild_permissions.manage_channels:
-            await ctx.send(_("I need the `Manage channels` permission to continue."))
-            return
-        await ctx.send(
-            _("Now checking {len} channels, please wait...").format(len=len(guild.channels))
-        )
-        perms = discord.PermissionOverwrite(send_messages=False, add_reactions=False, speak=False)
-        reason = _("WarnSystem mute role permissions refresh")
-        perms_failed = []  # if it failed because of Forbidden, add to this list
-        other_failed = []  # if it failed because of HTTPException, add to this one
-        count = 0
-        category: discord.CategoryChannel
-        async with ctx.typing():
-            for channel in guild.channels:  # include categories, text and voice channels
-                # we check if the perms are correct, to prevent useless API calls
-                overwrites = channel.overwrites_for(mute_role)
-                if (
-                    isinstance(channel, discord.TextChannel)
-                    and overwrites.send_messages is False
-                    and overwrites.add_reactions is False
-                ):
-                    continue
-                elif isinstance(channel, discord.VoiceChannel) and overwrites.speak is False:
-                    continue
-                elif overwrites == perms:
-                    continue
-                count += 1
-                try:
-                    log.debug(
-                        f"[Guild {guild.id}] Editing channel {channel.name} for "
-                        "mute role permissions refresh."
-                    )
-                    await channel.set_permissions(target=mute_role, overwrite=perms, reason=reason)
-                except discord.errors.Forbidden:
-                    perms_failed.append(channel)
-                except discord.errors.HTTPException as e:
-                    log.error(
-                        f"[Guild {guild.id}] Failed to edit channel {channel.name} "
-                        f"({channel.id}) while refreshing the mute role's permissions.",
-                        exc_info=e,
-                    )
-                    other_failed.append(channel)
-        if not perms_failed and not other_failed:
-            await ctx.send(
-                _("Successfully checked all channels, {len} were edited.").format(len=count)
-            )
-            return
-
-        def format_channels(channels: list):
-            text = ""
-            for channel in sorted(channels, key=lambda x: x.position):
-                if isinstance(channel, discord.TextChannel):
-                    text += f"- Text channel: {channel.mention}"
-                elif isinstance(channel, discord.VoiceChannel):
-                    text += f"- Voice channel: {channel.name}"
-                else:
-                    text += f"- Category: {channel.name}"
-            return text
-
-        text = _("Successfully checked all channels, {len}/{total} were edited.\n\n").format(
-            len=count - len(perms_failed) - len(other_failed), total=count
-        )
-        if perms_failed:
-            text += _(
-                "The following channels were not updated due to a permission failure, "
-                "probably enforced `Manage channels` permission:\n{channels}\n"
-            ).format(channels=format_channels(perms_failed))
-        if other_failed:
-            text += _(
-                "The following channels were not updated due to an unknown error "
-                "(check your logs or ask the bot administrator):\n{channels}\n"
-            ).format(channels=format_channels(other_failed))
-        text += _("You can fix these issues and run the command once again.")
-        for page in pagify(text):
-            await ctx.send(page)
-
     @warnset.command(name="reinvite")
     async def warnset_reinvite(self, ctx: commands.Context, enable: bool = None):
         """
@@ -648,7 +474,9 @@ channels, and prevented from talking in all voice channels.
                 _(
                     "The bot {respect} reinvite unbanned members. If you want to "
                     "change this, type `[p]warnset reinvite {opposite}`."
-                ).format(respect=_("does") if current else _("doesn't"), opposite=not current)
+                ).format(
+                    respect=_("does") if current else _("doesn't"), opposite=not current
+                )
             )
         elif enable:
             await self.data.guild(guild).reinvite.set(True)
@@ -662,40 +490,6 @@ channels, and prevented from talking in all voice channels.
         else:
             await self.data.guild(guild).reinvite.set(False)
             await ctx.send(_("Done. The bot will no longer reinvite unbanned members."))
-
-    @warnset.command("removeroles")
-    async def warnset_removeroles(self, ctx: commands.Context, enable: bool = None):
-        """
-        Defines if the bot should remove all roles on mute
-
-        If enabled, when you set a level 2 warning on a member, they will be assigned the mute role\
-        as usual, but all of their other roles will also be removed.
-        Once the mute ends, the member will get their roles back.
-        This can be useful for role permissions issues.
-        """
-        guild = ctx.guild
-        current = await self.data.guild(guild).remove_roles()
-        if enable is None:
-            await ctx.send(
-                _(
-                    "The bot currently {remove} all roles on mute. If you want to change this, "
-                    "type `[p]warnset removeroles {opposite}`."
-                ).format(
-                    remove=_("removes") if current else _("doesn't remove"), opposite=not current
-                )
-            )
-        elif enable:
-            await self.data.guild(guild).remove_roles.set(True)
-            await ctx.send(
-                _(
-                    "Done. All roles will be removed from muted members. They will get their "
-                    "roles back once the mute ends or when someone removes the warning using the "
-                    "`{prefix}warnings` command."
-                ).format(prefix=ctx.prefix)
-            )
-        else:
-            await self.data.guild(guild).remove_roles.set(False)
-            await ctx.send(_("Done. Muted members will keep their roles on mute."))
 
     @warnset.command(name="settings")
     async def warnset_settings(self, ctx: commands.Context):
@@ -716,23 +510,23 @@ channels, and prevented from talking in all voice channels.
                 if not channel:
                     if key != "main":
                         continue
-                    channel = _("Not set. Use `{prefix}warnset channel`").format(prefix=ctx.prefix)
+                    channel = _("Not set. Use `{prefix}warnset channel`").format(
+                        prefix=ctx.prefix
+                    )
                 else:
                     channel = guild.get_channel(channel)
                     channel = channel.mention if channel else _("Not found")
                 if key == "main":
-                    channels += _("Default channel: {channel}\n").format(channel=channel)
+                    channels += _("Default channel: {channel}\n").format(
+                        channel=channel
+                    )
                 else:
                     channels += _("Level {level} warnings channel: {channel}\n").format(
                         channel=channel, level=key
                     )
-            mute_role = guild.get_role(all_data["mute_role"])
-            mute_role = _("No mute role set.") if not mute_role else mute_role.name
             hierarchy = _("Enabled") if all_data["respect_hierarchy"] else _("Disabled")
             reinvite = _("Enabled") if all_data["reinvite"] else _("Disabled")
             show_mod = _("Enabled") if all_data["show_mod"] else _("Disabled")
-            update_mute = _("Enabled") if all_data["update_mute"] else _("Disabled")
-            remove_roles = _("Enabled") if all_data["remove_roles"] else _("Disabled")
             manual_bans = _("Enabled") if all_data["log_manual"] else _("Disabled")
             bandays = _("Softban: {softban}\nBan: {ban}").format(
                 softban=all_data["bandays"]["softban"], ban=all_data["bandays"]["ban"]
@@ -795,19 +589,18 @@ channels, and prevented from talking in all voice channels.
                 embed.set_footer(text=_("Cog made with ❤️ by Laggron"))
                 embed.colour = color
             embeds[0].add_field(name=_("Log channels"), value=channels)
-            embeds[0].add_field(name=_("Mute role"), value=mute_role)
             embeds[0].add_field(name=_("Respect hierarchy"), value=hierarchy)
             embeds[0].add_field(name=_("Reinvite unbanned members"), value=reinvite)
             embeds[0].add_field(name=_("Show responsible moderator"), value=show_mod)
             embeds[0].add_field(name=_("Detect manual actions"), value=manual_bans)
-            embeds[0].add_field(name=_("Update new channels for mute role"), value=update_mute)
-            embeds[0].add_field(name=_("Remove roles on mute"), value=remove_roles)
             embeds[0].add_field(name=_("Days of messages to delete"), value=bandays)
             embeds[0].add_field(name=_("Substitutions"), value=substitutions)
             embeds[1].add_field(name=_("Embed thumbnails"), value=embed_thumbnails)
             embeds[1].add_field(name=_("Embed colors"), value=embed_colors)
             embeds[1].add_field(
-                name=_("Modlog embed descriptions"), value=modlog_descriptions, inline=False
+                name=_("Modlog embed descriptions"),
+                value=modlog_descriptions,
+                inline=False,
             )
             embeds[1].add_field(
                 name=_("User embed descriptions"), value=user_descriptions, inline=False
@@ -821,7 +614,9 @@ channels, and prevented from talking in all voice channels.
                 inline=False,
             )
         try:
-            await menus.menu(ctx=ctx, pages=embeds, controls=menus.DEFAULT_CONTROLS, timeout=90)
+            await menus.menu(
+                ctx=ctx, pages=embeds, controls=menus.DEFAULT_CONTROLS, timeout=90
+            )
         except discord.errors.HTTPException as e:
             log.error("Couldn't make embed for displaying settings.", exc_info=e)
             await ctx.send(
@@ -847,7 +642,9 @@ channels, and prevented from talking in all voice channels.
                 _(
                     "The bot {respect} show the responsible moderator to the warned member in DM. "
                     "If you want to change this, type `[p]warnset showmod {opposite}`."
-                ).format(respect=_("does") if current else _("doesn't"), opposite=not current)
+                ).format(
+                    respect=_("does") if current else _("doesn't"), opposite=not current
+                )
             )
         elif enable:
             await self.data.guild(guild).show_mod.set(True)
@@ -859,7 +656,9 @@ channels, and prevented from talking in all voice channels.
             )
         else:
             await self.data.guild(guild).show_mod.set(False)
-            await ctx.send(_("Done. The bot will no longer show the responsible moderator."))
+            await ctx.send(
+                _("Done. The bot will no longer show the responsible moderator.")
+            )
 
     @warnset.group(name="substitutions")
     async def warnset_substitutions(self, ctx: commands.Context):
@@ -877,7 +676,9 @@ channels, and prevented from talking in all voice channels.
         pass
 
     @warnset_substitutions.command(name="add")
-    async def warnset_substitutions_add(self, ctx: commands.Context, name: str, *, text: str):
+    async def warnset_substitutions_add(
+            self, ctx: commands.Context, name: str, *, text: str
+    ):
         """
         Create a new subsitution.
 
@@ -899,7 +700,9 @@ channels, and prevented from talking in all voice channels.
                 )
                 return
             if len(text) > 600:
-                await ctx.send(_("That substitution is too long! Maximum is 600 characters!"))
+                await ctx.send(
+                    _("That substitution is too long! Maximum is 600 characters!")
+                )
                 return
             substitutions[name] = text
         await ctx.send(
@@ -959,7 +762,9 @@ channels, and prevented from talking in all voice channels.
             )
 
     @warnset.command(name="thumbnail")
-    async def warnset_thumbnail(self, ctx: commands.Context, level: int, url: str = None):
+    async def warnset_thumbnail(
+            self, ctx: commands.Context, level: int, url: str = None
+    ):
         """
         Edit the image displayed on the embeds.
 
@@ -973,7 +778,7 @@ channels, and prevented from talking in all voice channels.
             return
         await self.data.guild(guild).thumbnails.set_raw(str(level), value=url)
         await ctx.send(
-            _("The new image for level {level} warnings has been set to {image}.").format(
-                level=level, image=url
-            )
+            _(
+                "The new image for level {level} warnings has been set to {image}."
+            ).format(level=level, image=url)
         )

--- a/warnsystem/settings.py
+++ b/warnsystem/settings.py
@@ -216,7 +216,6 @@ class SettingsMixin(MixinMeta):
                             "reason": case["reason"],
                             "time": timestamp,
                             "duration": None,
-                            "roles": [],
                         }
                     )
                     total_cases += 1

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -194,6 +194,8 @@ class WarnSystem(
             await ctx.send(e)
         except errors.SuicidePrevention as e:
             await ctx.send(e)
+        except errors.BadArgument as e:
+            await ctx.send(e)
         except errors.NotFound:
             await ctx.send(
                 _(

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -823,32 +823,6 @@ class WarnSystem(
         )
 
     @commands.command()
-    @checks.mod_or_permissions(moderate_members=True)
-    async def wsunmute(
-            self, ctx: commands.Context, member: discord.Member
-    ):  # TODO: Keep Mute?
-        """
-        Remove a timeout from a member within the WarnSystem.
-
-        *wsunmute = WarnSystem unmute. Feel free to add an alias.*
-        """
-        guild = ctx.guild
-        if member.timed_out_until is None:
-            await ctx.send(_("That member isn't timed out."))
-            return
-        case = await self.cache.get_temp_action(guild, member)
-        if case and case["level"] == 2:
-            await self.cache.remove_temp_action(guild, member)
-
-        await member.timeout(
-            None,
-            reason=_(
-                "[WarnSystem] Member timeout removed by {author} (ID: {author.id})"
-            ).format(author=ctx.author),
-        )
-        await ctx.send(_("Member timeout removed."))
-
-    @commands.command()
     @commands.bot_has_permissions(ban_members=True)
     @checks.mod_or_permissions(ban_members=True)
     async def wsunban(self, ctx: commands.Context, member_id: int):

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -46,9 +46,7 @@ class CompositeMetaClass(type(commands.Cog), type(ABC)):
 
 
 @cog_i18n(_)
-class WarnSystem(
-    SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeMetaClass
-):
+class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeMetaClass):
     """
     An alternative to the Red core moderation system, providing a different system of moderation\
     similar to Dyno.
@@ -153,13 +151,13 @@ class WarnSystem(
 
     # helpers
     async def call_warn(
-            self,
-            ctx: commands.Context,
-            level: int,
-            member: discord.Member,
-            reason: Optional[str] = None,
-            time: Optional[timedelta] = None,
-            ban_days: Optional[int] = None,
+        self,
+        ctx: commands.Context,
+        level: int,
+        member: discord.Member,
+        reason: Optional[str] = None,
+        time: Optional[timedelta] = None,
+        ban_days: Optional[int] = None,
     ):
         """No need to repeat, let's do what's common to all 5 warnings."""
         reason = await self.api.format_reason(ctx.guild, reason)
@@ -219,17 +217,17 @@ class WarnSystem(
                 await ctx.send(_("Done."))
 
     async def call_masswarn(
-            self,
-            ctx: commands.Context,
-            level: int,
-            members: list[discord.Member],
-            unavailable_members: list[UnavailableMember],
-            log_modlog: bool,
-            log_dm: bool,
-            take_action: bool,
-            reason: Optional[str] = None,
-            time: Optional[timedelta] = None,
-            confirm: bool = False,
+        self,
+        ctx: commands.Context,
+        level: int,
+        members: list[discord.Member],
+        unavailable_members: list[UnavailableMember],
+        log_modlog: bool,
+        log_dm: bool,
+        take_action: bool,
+        reason: Optional[str] = None,
+        time: Optional[timedelta] = None,
+        confirm: bool = False,
     ):
         guild = ctx.guild
         message = None
@@ -278,9 +276,7 @@ class WarnSystem(
                 await asyncio.sleep(5)
 
         if unavailable_members and level < 5:
-            await ctx.send(
-                _("You can only use `--hackban-select` with a level 5 warn.")
-            )
+            await ctx.send(_("You can only use `--hackban-select` with a level 5 warn."))
             return
         reason = await self.api.format_reason(ctx.guild, reason)
         if (log_modlog or log_dm) and reason and len(reason) > 2000:  # embed limits
@@ -344,9 +340,7 @@ class WarnSystem(
                 ),
                 file=file,
             )
-            menus.start_adding_reactions(
-                msg, predicates.ReactionPredicate.YES_OR_NO_EMOJIS
-            )
+            menus.start_adding_reactions(msg, predicates.ReactionPredicate.YES_OR_NO_EMOJIS)
             pred = predicates.ReactionPredicate.yes_or_no(msg, ctx.author)
             try:
                 await self.bot.wait_for("reaction_add", check=pred, timeout=120)
@@ -393,9 +387,7 @@ class WarnSystem(
             if not confirm:
                 if fails:
                     await ctx.send(
-                        _(
-                            "Done! {failed} {members} out of {total} couldn't be warned."
-                        ).format(
+                        _("Done! {failed} {members} out of {total} couldn't be warned.").format(
                             failed=len(fails),
                             members=_("members") if len(fails) > 1 else _("member"),
                             total=total_members,
@@ -423,9 +415,7 @@ class WarnSystem(
     @commands.group(invoke_without_command=True, name="warn")
     @checks.mod_or_permissions(administrator=True)
     @commands.guild_only()
-    async def _warn(
-            self, ctx: commands.Context, member: discord.Member, *, reason: str = None
-    ):
+    async def _warn(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """
         Take actions against a user and log it.
         The warned user will receive a DM.
@@ -436,9 +426,7 @@ class WarnSystem(
 
     @_warn.command(name="1", aliases=["simple"])
     @checks.mod_or_permissions(administrator=True)
-    async def warn_1(
-            self, ctx: commands.Context, member: discord.Member, *, reason: str = None
-    ):
+    async def warn_1(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """
         Set a simple warning on a user.
 
@@ -449,12 +437,12 @@ class WarnSystem(
     @_warn.command(name="2", aliases=["mute", "timeout"])
     @checks.mod_or_permissions(administrator=True)
     async def warn_2(
-            self,
-            ctx: commands.Context,
-            member: discord.Member,
-            time: TimedeltaConverter,
-            *,
-            reason: Optional[str] = None,
+        self,
+        ctx: commands.Context,
+        member: discord.Member,
+        time: TimedeltaConverter,
+        *,
+        reason: Optional[str] = None,
     ):
         """
         Timeout the user in all channels, including voice channels.
@@ -470,11 +458,11 @@ class WarnSystem(
     @_warn.command(name="3", aliases=["kick"])
     @checks.mod_or_permissions(administrator=True)
     async def warn_3(
-            self,
-            ctx: commands.Context,
-            member: discord.Member,
-            *,
-            reason: Optional[str] = None,
+        self,
+        ctx: commands.Context,
+        member: discord.Member,
+        *,
+        reason: Optional[str] = None,
     ):
         """
         Kick the member from the server.
@@ -484,11 +472,11 @@ class WarnSystem(
     @_warn.command(name="4", aliases=["softban"])
     @checks.mod_or_permissions(administrator=True)
     async def warn_4(
-            self,
-            ctx: commands.Context,
-            member: discord.Member,
-            *,
-            reason: Optional[str] = None,
+        self,
+        ctx: commands.Context,
+        member: discord.Member,
+        *,
+        reason: Optional[str] = None,
     ):
         """
         Softban the member from the server.
@@ -504,12 +492,12 @@ class WarnSystem(
     @_warn.command(name="5", aliases=["ban"], usage="<member> [time] <reason>")
     @checks.mod_or_permissions(administrator=True)
     async def warn_5(
-            self,
-            ctx: commands.Context,
-            member: UnavailableMember,
-            time: Optional[TimedeltaConverter],
-            *,
-            reason: Optional[str] = None,
+        self,
+        ctx: commands.Context,
+        member: UnavailableMember,
+        time: Optional[TimedeltaConverter],
+        *,
+        reason: Optional[str] = None,
     ):
         """
         Ban the member from the server.
@@ -715,10 +703,10 @@ class WarnSystem(
     @commands.guild_only()
     @commands.cooldown(1, 3, commands.BucketType.member)
     async def warnings(
-            self,
-            ctx: commands.Context,
-            user: Optional[UnavailableMember] = None,
-            index: int = 0,
+        self,
+        ctx: commands.Context,
+        user: Optional[UnavailableMember] = None,
+        index: int = 0,
     ):
         """
         Shows all warnings of a member.
@@ -730,11 +718,11 @@ class WarnSystem(
             await ctx.send_help()
             return
         if (
-                not (
-                        await mod.is_mod_or_superior(self.bot, ctx.author)
-                        or ctx.author.guild_permissions.kick_members
-                )
-                and user != ctx.author
+            not (
+                await mod.is_mod_or_superior(self.bot, ctx.author)
+                or ctx.author.guild_permissions.kick_members
+            )
+            and user != ctx.author
         ):
             await ctx.send(_("You are not allowed to see other's warnings!"))
             return
@@ -804,10 +792,7 @@ class WarnSystem(
             text += "\n\n"
             full_text = text + full_text
         pages = [
-            x
-            for x in pagify(
-                full_text, delims=["\n\n", "\n"], priority=True, page_length=1900
-            )
+            x for x in pagify(full_text, delims=["\n\n", "\n"], priority=True, page_length=1900)
         ]
         total_pages = len(pages)
         total_warns = len(warns)
@@ -818,9 +803,7 @@ class WarnSystem(
             )
             for i, x in enumerate(pages, start=1)
         ]
-        await menus.menu(
-            ctx=ctx, pages=pages, controls=menus.DEFAULT_CONTROLS, timeout=60
-        )
+        await menus.menu(ctx=ctx, pages=pages, controls=menus.DEFAULT_CONTROLS, timeout=60)
 
     @commands.command()
     @commands.bot_has_permissions(ban_members=True)
@@ -841,9 +824,7 @@ class WarnSystem(
         try:
             await guild.unban(member)
         except discord.errors.HTTPException as e:
-            await ctx.send(
-                _("Failed to unban the given member. Check your logs for details.")
-            )
+            await ctx.send(_("Failed to unban the given member. Check your logs for details."))
             log.error(
                 f"Can't unban user {member.id} from guild {guild} ({guild.id})",
                 exc_info=e,
@@ -877,9 +858,7 @@ class WarnSystem(
         # if a member gets unbanned, we check if they were temp banned with warnsystem
         # if it was, we remove the case so it won't unban them a second time
         warns = await self.cache.get_temp_action(guild)
-        to_remove = (
-            []
-        )  # there can be multiple temp bans, let's not question the moderators
+        to_remove = []  # there can be multiple temp bans, let's not question the moderators
         for member, data in warns.items():
             if data["level"] == 2 or int(member) != user.id:
                 continue
@@ -899,9 +878,7 @@ class WarnSystem(
     async def on_member_remove(self, member: discord.Member):
         await self.on_manual_action(member.guild, member, 3)
 
-    async def on_manual_action(
-            self, guild: discord.Guild, member: discord.Member, level: int
-    ):
+    async def on_manual_action(self, guild: discord.Guild, member: discord.Member, level: int):
         # most of this code is from Cog-Creators, modlog cog
         # https://github.com/Cog-Creators/Red-DiscordBot/blob/bc21f779762ec9f460aecae525fdcd634f6c2d85/redbot/core/modlog.py#L68
         if not guild.me.guild_permissions.view_audit_log:
@@ -916,9 +893,7 @@ class WarnSystem(
         when = datetime.now(timezone.utc)
         before = when + timedelta(minutes=1)
         after = when - timedelta(minutes=1)
-        await asyncio.sleep(
-            10
-        )  # prevent small delays from causing a 5 minute delay on entry
+        await asyncio.sleep(10)  # prevent small delays from causing a 5 minute delay on entry
         attempts = 0
         action = {
             3: discord.AuditLogAction.kick,
@@ -928,13 +903,8 @@ class WarnSystem(
         while attempts < 3:
             attempts += 1
             try:
-                async for entry in guild.audit_logs(
-                        action=action, before=before, after=after
-                ):
-                    if (
-                            entry.target.id == member.id
-                            and after < entry.created_at < before
-                    ):
+                async for entry in guild.audit_logs(action=action, before=before, after=after):
+                    if entry.target.id == member.id and after < entry.created_at < before:
                         break
                 else:
                     break
@@ -948,9 +918,7 @@ class WarnSystem(
                         # Don't create modlog entires for the bot's own bans, cogs do this.
                         mod, reason, date = entry.user, entry.reason, entry.created_at
                         if isinstance(member, discord.User):
-                            member = UnavailableMember(
-                                self.bot, guild._state, member.id
-                            )
+                            member = UnavailableMember(self.bot, guild._state, member.id)
                         try:
                             await self.api.warn(
                                 guild,
@@ -1013,9 +981,7 @@ class WarnSystem(
                     "\n\n\n--- Case {number} ---\nLevel:     {level}\nReason:    {reason}\n"
                 ).format(number=i + 1, **modlog)
                 text += "Date:      {date}\n".format(
-                    date=self.api._format_datetime(
-                        self.api._get_datetime(modlog["time"])
-                    )
+                    date=self.api._format_datetime(self.api._get_datetime(modlog["time"]))
                 )
                 if modlog["duration"]:
                     duration = self.api._get_timedelta(modlog["duration"])
@@ -1057,9 +1023,7 @@ class WarnSystem(
 
     async def red_delete_data_for_user(self, *, requester: str, user_id: int):
         try:
-            result = await self._red_delete_data_for_user(
-                requester=requester, user_id=user_id
-            )
+            result = await self._red_delete_data_for_user(requester=requester, user_id=user_id)
         except Exception as e:
             log.error(
                 f"User {user_id} has requested end user data deletion but an exception occured!",

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1047,10 +1047,6 @@ class WarnSystem(
                         duration=self.api._format_timedelta(duration),
                         raw=modlog["duration"],
                     )
-                if modlog["roles"]:
-                    text += "Roles:     {roles}\n".format(
-                        roles=", ".join(modlog["roles"])
-                    )
             file = BytesIO()
             file.write(text.encode("utf-8"))
             files[guild_id] = file

--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -46,7 +46,9 @@ class CompositeMetaClass(type(commands.Cog), type(ABC)):
 
 
 @cog_i18n(_)
-class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeMetaClass):
+class WarnSystem(
+    SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeMetaClass
+):
     """
     An alternative to the Red core moderation system, providing a different system of moderation\
     similar to Dyno.
@@ -61,9 +63,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     default_guild = {
         "delete_message": False,  # if the [p]warn commands should delete the context message
         "show_mod": False,  # if the responsible mod should be revealed to the warned user
-        "mute_role": None,  # the role used for mute
-        "update_mute": False,  # if the bot should update perms of each new text channel/category
-        "remove_roles": False,  # if the bot should remove all other roles on mute
         "respect_hierarchy": False,  # if the bot should check if the mod is allowed by hierarchy
         # TODO use bot settingfor respect_hierarchy ?
         "reinvite": True,  # if the bot should try to send an invite to an unbanned/kicked member
@@ -110,7 +109,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             "5": 0xFF4C4C,
         },
         "url": None,  # URL set for the title of all embeds
-        "temporary_warns": {},  # list of temporary warns (need to unmute/unban after some time)
+        "temporary_warns": {},  # list of temporary warns (need to unban after some time)
         "automod": {  # everything related to auto moderation
             "enabled": False,
             "antispam": {
@@ -154,13 +153,13 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
 
     # helpers
     async def call_warn(
-        self,
-        ctx: commands.Context,
-        level: int,
-        member: discord.Member,
-        reason: Optional[str] = None,
-        time: Optional[timedelta] = None,
-        ban_days: Optional[int] = None,
+            self,
+            ctx: commands.Context,
+            level: int,
+            member: discord.Member,
+            reason: Optional[str] = None,
+            time: Optional[timedelta] = None,
+            ban_days: Optional[int] = None,
     ):
         """No need to repeat, let's do what's common to all 5 warnings."""
         reason = await self.api.format_reason(ctx.guild, reason)
@@ -195,13 +194,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             await ctx.send(e)
         except errors.SuicidePrevention as e:
             await ctx.send(e)
-        except errors.MissingMuteRole:
-            await ctx.send(
-                _(
-                    "You need to set up the mute role before doing this.\n"
-                    "Use the `[p]warnset mute` command for this."
-                )
-            )
         except errors.NotFound:
             await ctx.send(
                 _(
@@ -210,19 +202,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                     "*Use the `[p]warnset channel` command.*\n\n"
                     "**With Red Modlog**\n"
                     "*Load the `modlogs` cog and use the `[p]modlogset modlog` command.*"
-                )
-            )
-        except errors.NotAllowedByHierarchy:
-            is_admin = mod.is_admin_or_superior(self.bot, member)
-            await ctx.send(
-                _(
-                    "You are not allowed to do this, {member} is higher than you in the role "
-                    "hierarchy. You can only warn members which top role is lower than yours.\n\n"
-                ).format(member=str(member))
-                + (
-                    _("You can disable this check by using the `[p]warnset hierarchy` command.")
-                    if is_admin
-                    else ""
                 )
             )
         except discord.errors.NotFound:
@@ -238,17 +217,17 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                 await ctx.send(_("Done."))
 
     async def call_masswarn(
-        self,
-        ctx: commands.Context,
-        level: int,
-        members: list[discord.Member],
-        unavailable_members: list[UnavailableMember],
-        log_modlog: bool,
-        log_dm: bool,
-        take_action: bool,
-        reason: Optional[str] = None,
-        time: Optional[timedelta] = None,
-        confirm: bool = False,
+            self,
+            ctx: commands.Context,
+            level: int,
+            members: list[discord.Member],
+            unavailable_members: list[UnavailableMember],
+            log_modlog: bool,
+            log_dm: bool,
+            take_action: bool,
+            reason: Optional[str] = None,
+            time: Optional[timedelta] = None,
+            confirm: bool = False,
     ):
         guild = ctx.guild
         message = None
@@ -297,7 +276,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                 await asyncio.sleep(5)
 
         if unavailable_members and level < 5:
-            await ctx.send(_("You can only use `--hackban-select` with a level 5 warn."))
+            await ctx.send(
+                _("You can only use `--hackban-select` with a level 5 warn.")
+            )
             return
         reason = await self.api.format_reason(ctx.guild, reason)
         if (log_modlog or log_dm) and reason and len(reason) > 2000:  # embed limits
@@ -350,16 +331,20 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                     time=time_str,
                     tick5=tick5,
                     reason=reason or _("Not set"),
-                    warning=_(
-                        ":warning: You're about to warn a lot of members! Avoid doing this to "
-                        "prevent being rate limited by Discord, especially if you enabled DMs.\n\n"
-                    )
-                    if len(members) > 50 and level > 1
-                    else "",
+                    warning=(
+                        _(
+                            ":warning: You're about to warn a lot of members! Avoid doing this to "
+                            "prevent being rate limited by Discord, especially if you enabled DMs.\n\n"
+                        )
+                        if len(members) > 50 and level > 1
+                        else ""
+                    ),
                 ),
                 file=file,
             )
-            menus.start_adding_reactions(msg, predicates.ReactionPredicate.YES_OR_NO_EMOJIS)
+            menus.start_adding_reactions(
+                msg, predicates.ReactionPredicate.YES_OR_NO_EMOJIS
+            )
             pred = predicates.ReactionPredicate.yes_or_no(msg, ctx.author)
             try:
                 await self.bot.wait_for("reaction_add", check=pred, timeout=120)
@@ -391,14 +376,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             await ctx.send(e)
         except errors.LostPermissions as e:
             await ctx.send(e)
-        except errors.MissingMuteRole:
-            if not confirm:
-                await ctx.send(
-                    _(
-                        "You need to set up the mute role before doing this.\n"
-                        "Use the `[p]warnset mute` command for this."
-                    )
-                )
         except errors.NotFound:
             if not confirm:
                 await ctx.send(
@@ -414,7 +391,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             if not confirm:
                 if fails:
                     await ctx.send(
-                        _("Done! {failed} {members} out of {total} couldn't be warned.").format(
+                        _(
+                            "Done! {failed} {members} out of {total} couldn't be warned."
+                        ).format(
                             failed=len(fails),
                             members=_("members") if len(fails) > 1 else _("member"),
                             total=total_members,
@@ -442,7 +421,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     @commands.group(invoke_without_command=True, name="warn")
     @checks.mod_or_permissions(administrator=True)
     @commands.guild_only()
-    async def _warn(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
+    async def _warn(
+            self, ctx: commands.Context, member: discord.Member, *, reason: str = None
+    ):
         """
         Take actions against a user and log it.
         The warned user will receive a DM.
@@ -453,7 +434,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
 
     @_warn.command(name="1", aliases=["simple"])
     @checks.mod_or_permissions(administrator=True)
-    async def warn_1(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
+    async def warn_1(
+            self, ctx: commands.Context, member: discord.Member, *, reason: str = None
+    ):
         """
         Set a simple warning on a user.
 
@@ -461,35 +444,35 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         """
         await self.call_warn(ctx, 1, member, reason)
 
-    @_warn.command(name="2", aliases=["mute"])
+    @_warn.command(name="2", aliases=["mute", "timeout"])
     @checks.mod_or_permissions(administrator=True)
     async def warn_2(
-        self,
-        ctx: commands.Context,
-        member: discord.Member,
-        time: Optional[TimedeltaConverter],
-        *,
-        reason: Optional[str] = None,
+            self,
+            ctx: commands.Context,
+            member: discord.Member,
+            time: TimedeltaConverter,
+            *,
+            reason: Optional[str] = None,
     ):
         """
-        Mute the user in all channels, including voice channels.
+        Timeout the user in all channels, including voice channels.
 
-        This mute will use a role that will automatically be created, if it was not already done.
-        Feel free to edit the role's permissions and move it in the roles hierarchy.
-
-        You can set a timed mute by providing a valid time before the reason.
+        You can set a timeout by providing a valid time before the reason.
 
         Examples:
-        - `[p]warn 2 @user 30m`: 30 minutes mute
-        - `[p]warn 2 @user 5h Spam`: 5 hours mute for the reason "Spam"
-        - `[p]warn 2 @user Advertising`: Infinite mute for the reason "Advertising"
+        - `[p]warn 2 @user 30m`: 30-minute timeout
+        - `[p]warn 2 @user 5h Spam`: 5-hour timeout for the reason "Spam"
         """
         await self.call_warn(ctx, 2, member, reason, time)
 
     @_warn.command(name="3", aliases=["kick"])
     @checks.mod_or_permissions(administrator=True)
     async def warn_3(
-        self, ctx: commands.Context, member: discord.Member, *, reason: Optional[str] = None
+            self,
+            ctx: commands.Context,
+            member: discord.Member,
+            *,
+            reason: Optional[str] = None,
     ):
         """
         Kick the member from the server.
@@ -499,7 +482,11 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     @_warn.command(name="4", aliases=["softban"])
     @checks.mod_or_permissions(administrator=True)
     async def warn_4(
-        self, ctx: commands.Context, member: discord.Member, *, reason: Optional[str] = None
+            self,
+            ctx: commands.Context,
+            member: discord.Member,
+            *,
+            reason: Optional[str] = None,
     ):
         """
         Softban the member from the server.
@@ -515,12 +502,12 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     @_warn.command(name="5", aliases=["ban"], usage="<member> [time] <reason>")
     @checks.mod_or_permissions(administrator=True)
     async def warn_5(
-        self,
-        ctx: commands.Context,
-        member: UnavailableMember,
-        time: Optional[TimedeltaConverter],
-        *,
-        reason: Optional[str] = None,
+            self,
+            ctx: commands.Context,
+            member: UnavailableMember,
+            time: Optional[TimedeltaConverter],
+            *,
+            reason: Optional[str] = None,
     ):
         """
         Ban the member from the server.
@@ -608,11 +595,11 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             selection.confirm,
         )
 
-    @masswarn.command(name="2", aliases=["mute"])
+    @masswarn.command(name="2", aliases=["mute", "timeout"])
     @checks.mod_or_permissions(administrator=True)
     async def masswarn_2(self, ctx: commands.Context, *selection: str):
         """
-        Perform a mass mute.
+        Perform a mass timeout.
 
         You can provide a duration with the `--time` flag, the format is the same as the simple\
         level 2 warning.
@@ -726,7 +713,10 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     @commands.guild_only()
     @commands.cooldown(1, 3, commands.BucketType.member)
     async def warnings(
-        self, ctx: commands.Context, user: Optional[UnavailableMember] = None, index: int = 0
+            self,
+            ctx: commands.Context,
+            user: Optional[UnavailableMember] = None,
+            index: int = 0,
     ):
         """
         Shows all warnings of a member.
@@ -738,11 +728,11 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             await ctx.send_help()
             return
         if (
-            not (
-                await mod.is_mod_or_superior(self.bot, ctx.author)
-                or ctx.author.guild_permissions.kick_members
-            )
-            and user != ctx.author
+                not (
+                        await mod.is_mod_or_superior(self.bot, ctx.author)
+                        or ctx.author.guild_permissions.kick_members
+                )
+                and user != ctx.author
         ):
             await ctx.send(_("You are not allowed to see other's warnings!"))
             return
@@ -757,7 +747,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         total = lambda level: len([x for x in cases if x["level"] == level])
         warning_str = lambda level, plural: {
             1: (_("Warning"), _("Warnings")),
-            2: (_("Mute"), _("Mutes")),
+            2: (_("Timeout"), _("Timeouts")),
             3: (_("Kick"), _("Kicks")),
             4: (_("Softban"), _("Softbans")),
             5: (_("Ban"), _("Bans")),
@@ -772,7 +762,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         embed = discord.Embed(description=_("User modlog summary."))
         embed.set_author(name=f"{user} | {user.id}", icon_url=user.display_avatar.url)
         embed.add_field(
-            name=_("Total number of warnings: ") + str(len(cases)), value=warn_field, inline=False
+            name=_("Total number of warnings: ") + str(len(cases)),
+            value=warn_field,
+            inline=False,
         )
         embed.colour = user.top_role.colour
 
@@ -810,7 +802,10 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             text += "\n\n"
             full_text = text + full_text
         pages = [
-            x for x in pagify(full_text, delims=["\n\n", "\n"], priority=True, page_length=1900)
+            x
+            for x in pagify(
+                full_text, delims=["\n\n", "\n"], priority=True, page_length=1900
+            )
         ]
         total_pages = len(pages)
         total_warns = len(warns)
@@ -821,72 +816,35 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             )
             for i, x in enumerate(pages, start=1)
         ]
-        await menus.menu(ctx=ctx, pages=pages, controls=menus.DEFAULT_CONTROLS, timeout=60)
+        await menus.menu(
+            ctx=ctx, pages=pages, controls=menus.DEFAULT_CONTROLS, timeout=60
+        )
 
     @commands.command()
-    @checks.mod_or_permissions(manage_roles=True)
-    async def wsunmute(self, ctx: commands.Context, member: discord.Member):
+    @checks.mod_or_permissions(moderate_members=True)
+    async def wsunmute(
+            self, ctx: commands.Context, member: discord.Member
+    ):  # TODO: Keep Mute?
         """
-        Unmute a member muted with WarnSystem.
-
-        If the member's roles were removed, they will be granted back.
+        Remove a timeout from a member within the WarnSystem.
 
         *wsunmute = WarnSystem unmute. Feel free to add an alias.*
         """
         guild = ctx.guild
-        mute_role = guild.get_role(await self.cache.get_mute_role(guild))
-        if not mute_role:
-            await ctx.send(_("The mute role is not set or lost."))
-            return
-        if mute_role not in member.roles:
-            await ctx.send(_("That member isn't muted."))
+        if member.timed_out_until is None:
+            await ctx.send(_("That member isn't timed out."))
             return
         case = await self.cache.get_temp_action(guild, member)
         if case and case["level"] == 2:
-            roles = case["roles"]
             await self.cache.remove_temp_action(guild, member)
-        else:
-            cases = await self.api.get_all_cases(guild, member)
-            roles = []
-            for data in cases[::-1]:
-                if data["level"] == 2:
-                    try:
-                        roles = data["roles"]
-                    except KeyError:
-                        continue
-                    break
-        await member.remove_roles(
-            mute_role,
-            reason=_("[WarnSystem] Member unmuted by {author} (ID: {author.id})").format(
-                author=ctx.author
-            ),
+
+        await member.timeout(
+            None,
+            reason=_(
+                "[WarnSystem] Member timeout removed by {author} (ID: {author.id})"
+            ).format(author=ctx.author),
         )
-        roles = list(filter(None, [guild.get_role(x) for x in roles]))
-        if not roles:
-            await ctx.send(_("Member unmuted."))
-            return
-        await ctx.send(
-            _("Member unmuted. {len_roles} roles to reassign...").format(len_roles=len(roles))
-        )
-        async with ctx.typing():
-            fails = []
-            for role in roles:
-                try:
-                    await member.add_roles(role)
-                except discord.errors.HTTPException as e:
-                    log.error(
-                        f"Failed to reapply role {role} ({role.id}) on guild {guild} "
-                        f"({guild.id}) after unmute.",
-                        exc_info=e,
-                    )
-                    fails.append(role)
-        text = _("Done.")
-        if fails:
-            text.append(_("\n\nFailed to add {fails}/{len_roles} roles back:\n"))
-            for role in fails:
-                text.append(f"- {role.name}\n")
-        for page in pagify(text):
-            await ctx.send(page)
+        await ctx.send(_("Member timeout removed."))
 
     @commands.command()
     @commands.bot_has_permissions(ban_members=True)
@@ -907,8 +865,13 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         try:
             await guild.unban(member)
         except discord.errors.HTTPException as e:
-            await ctx.send(_("Failed to unban the given member. Check your logs for details."))
-            log.error(f"Can't unban user {member.id} from guild {guild} ({guild.id})", exc_info=e)
+            await ctx.send(
+                _("Failed to unban the given member. Check your logs for details.")
+            )
+            log.error(
+                f"Can't unban user {member.id} from guild {guild} ({guild.id})",
+                exc_info=e,
+            )
             return
         case = await self.cache.get_temp_action(guild, member)
         if case and case["level"] == 5:
@@ -938,7 +901,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         # if a member gets unbanned, we check if they were temp banned with warnsystem
         # if it was, we remove the case so it won't unban them a second time
         warns = await self.cache.get_temp_action(guild)
-        to_remove = []  # there can be multiple temp bans, let's not question the moderators
+        to_remove = (
+            []
+        )  # there can be multiple temp bans, let's not question the moderators
         for member, data in warns.items():
             if data["level"] == 2 or int(member) != user.id:
                 continue
@@ -951,53 +916,6 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             )
 
     @commands.Cog.listener()
-    async def on_member_update(self, before: discord.Member, after: discord.Member):
-        guild = after.guild
-        mute_role = guild.get_role(await self.cache.get_mute_role(guild))
-        if not mute_role:
-            return
-        if not (mute_role in before.roles and mute_role not in after.roles):
-            return
-        if after.id in self.cache.temp_actions:
-            await self.cache.remove_temp_action(guild, after)
-            log.info(
-                f"[Guild {guild.id}] The temporary mute of member {after} (ID: {after.id}) "
-                "was ended due to a manual unmute (role removed)."
-            )
-
-    @commands.Cog.listener()
-    async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):
-        guild = channel.guild
-        if isinstance(channel, discord.VoiceChannel):
-            return
-        if not await self.data.guild(guild).update_mute():
-            return
-        role = guild.get_role(await self.cache.get_mute_role(guild))
-        if not role:
-            return
-        try:
-            await channel.set_permissions(
-                role,
-                send_messages=False,
-                add_reactions=False,
-                reason=_(
-                    "Updating channel settings so the mute role will work here. "
-                    "Disable the auto-update with [p]warnset autoupdate"
-                ),
-            )
-        except discord.errors.Forbidden:
-            log.warn(
-                f"[Guild {guild.id}] Couldn't update permissions of new channel {channel.name} "
-                f"(ID: {channel.id}) due to a permission error."
-            )
-        except discord.errors.HTTPException as e:
-            log.error(
-                f"[Guild {guild.id}] Couldn't update permissions of new channel {channel.name} "
-                f"(ID: {channel.id}) due to an unknown error.",
-                exc_info=e,
-            )
-
-    @commands.Cog.listener()
     async def on_member_ban(self, guild: discord.Guild, member: discord.Member):
         await self.on_manual_action(guild, member, 5)
 
@@ -1005,7 +923,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     async def on_member_remove(self, member: discord.Member):
         await self.on_manual_action(member.guild, member, 3)
 
-    async def on_manual_action(self, guild: discord.Guild, member: discord.Member, level: int):
+    async def on_manual_action(
+            self, guild: discord.Guild, member: discord.Member, level: int
+    ):
         # most of this code is from Cog-Creators, modlog cog
         # https://github.com/Cog-Creators/Red-DiscordBot/blob/bc21f779762ec9f460aecae525fdcd634f6c2d85/redbot/core/modlog.py#L68
         if not guild.me.guild_permissions.view_audit_log:
@@ -1020,7 +940,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         when = datetime.now(timezone.utc)
         before = when + timedelta(minutes=1)
         after = when - timedelta(minutes=1)
-        await asyncio.sleep(10)  # prevent small delays from causing a 5 minute delay on entry
+        await asyncio.sleep(
+            10
+        )  # prevent small delays from causing a 5 minute delay on entry
         attempts = 0
         action = {
             3: discord.AuditLogAction.kick,
@@ -1030,8 +952,13 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
         while attempts < 3:
             attempts += 1
             try:
-                async for entry in guild.audit_logs(action=action, before=before, after=after):
-                    if entry.target.id == member.id and after < entry.created_at < before:
+                async for entry in guild.audit_logs(
+                        action=action, before=before, after=after
+                ):
+                    if (
+                            entry.target.id == member.id
+                            and after < entry.created_at < before
+                    ):
                         break
                 else:
                     break
@@ -1045,7 +972,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                         # Don't create modlog entires for the bot's own bans, cogs do this.
                         mod, reason, date = entry.user, entry.reason, entry.created_at
                         if isinstance(member, discord.User):
-                            member = UnavailableMember(self.bot, guild._state, member.id)
+                            member = UnavailableMember(
+                                self.bot, guild._state, member.id
+                            )
                         try:
                             await self.api.warn(
                                 guild,
@@ -1076,13 +1005,11 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             "https://github.com/retke/Laggrons-Dumb-Cogs/tree/v3/warnsystem#warnsystem\n\n"
             "As soon as a member is warned, the cog will store the following data:\n"
             "- User ID\n"
-            "- Warn level (from 1 to 5: warn, mute, kick, softban, ban)\n"
+            "- Warn level (from 1 to 5: warn, timeout, kick, softban, ban)\n"
             "- Warn reason\n"
             "- Warn author (responsible moderator. can be the bot in case of automated warns)\n"
             "- Date and time of the warn\n"
-            "- Duration of the warn (only in case of a temporary mute/ban)\n"
-            "- List of the roles the member had when they were muted "
-            "(only for mutes since version 1.2)\n\n"
+            "- Duration of the warn (only in case of a temporary timeout/ban)\n"
             "A list of files is provided, one for each server. The ID of the server is the name "
             "of the file. Servers without registered warnings are not included.\n\n"
             "Additonal notes:\n"
@@ -1110,7 +1037,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                     "\n\n\n--- Case {number} ---\nLevel:     {level}\nReason:    {reason}\n"
                 ).format(number=i + 1, **modlog)
                 text += "Date:      {date}\n".format(
-                    date=self.api._format_datetime(self.api._get_datetime(modlog["time"]))
+                    date=self.api._format_datetime(
+                        self.api._get_datetime(modlog["time"])
+                    )
                 )
                 if modlog["duration"]:
                     duration = self.api._get_timedelta(modlog["duration"])
@@ -1119,7 +1048,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
                         raw=modlog["duration"],
                     )
                 if modlog["roles"]:
-                    text += "Roles:     {roles}\n".format(roles=", ".join(modlog["roles"]))
+                    text += "Roles:     {roles}\n".format(
+                        roles=", ".join(modlog["roles"])
+                    )
             file = BytesIO()
             file.write(text.encode("utf-8"))
             files[guild_id] = file
@@ -1130,7 +1061,8 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
             data = await self._red_get_data_for_user(user_id=user_id)
         except Exception as e:
             log.error(
-                f"User {user_id} has requested end user data but an exception occured!", exc_info=e
+                f"User {user_id} has requested end user data but an exception occured!",
+                exc_info=e,
             )
             raise
         else:
@@ -1153,7 +1085,9 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
 
     async def red_delete_data_for_user(self, *, requester: str, user_id: int):
         try:
-            result = await self._red_delete_data_for_user(requester=requester, user_id=user_id)
+            result = await self._red_delete_data_for_user(
+                requester=requester, user_id=user_id
+            )
         except Exception as e:
             log.error(
                 f"User {user_id} has requested end user data deletion but an exception occured!",
@@ -1170,7 +1104,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, commands.Cog, metaclass=CompositeM
     def cog_unload(self):
         log.debug("Unloading cog...")
 
-        # stop checking for unmute and unban
+        # stop checking for unban
         self.task.cancel()
         self.api.disable_automod()
         self.api.re_pool.close()


### PR DESCRIPTION
## Pull request type

This PR replaces the old role-based mute system, with Discord's timeouts.

## Description of the changes
- Duration for warns with level 2 are now mandatory and are limited to 28d
- Removed everything related to role management and role settings for mutes
- Mutes got renamed to timeouts
- Warn System doesn't require role management related permissions, instead it requires moderate members permission

## Check-list

If useful, make a bullet list of the things done or not (will show up in the PR list). Example:

- [x] Properly naming command to remove timeouts
- [x] Require time for warn level 2 and check if it's within 28d in API
- [ ] Should we handle unmutes? If so, how?
- [ ] Testing
